### PR TITLE
Merge dev into main: UX/accessibility fixes, color system, reliability improvements

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.akshaykgupta.TwinPixCleaner</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>2.0.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Package.swift
+++ b/Package.swift
@@ -17,5 +17,9 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .testTarget(
+            name: "TwinPixCleanerTests",
+            dependencies: ["TwinPixCleaner"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ Unlike traditional duplicate cleaners, TwinPixCleaner can detect visually simila
 - 📸 **Apple Photos Integration** - Securely scan your entire macOS/iCloud Photos library via native PhotoKit
 - 🎯 **100% Accurate** - Finds exact duplicates safely, or visually identical variations
 - 🛡️ **Smart Selection** - 1-click "Keep This" workflow to select all duplicates except your favorite
-- 🗑️ **Safe Deletion & Undo** - Files moved to Trash or Photos "Recently Deleted" Album, reversible instantly with ⌘Z Undo 
+- 🗑️ **Safe Deletion & Undo** - Files moved to Trash or Photos "Recently Deleted" Album; an on-screen Undo toast and ⌘Z both restore them instantly
 - ✅ **Multi-Select** - Select multiple images for batch deletion
 - 👁️ **Native Quick Look** - Press Spacebar for instant, full-resolution interactive previews
 - 📊 **Smart Sorting** - Sort by size or number of copies
-- 🧊 **Frost Glass UI** - Stunning, interactive native macOS interface with dark mode support
+- 🧊 **Frost Glass UI** - Stunning, interactive native macOS interface with dark mode support, tinted to match your macOS accent color
 - ⌨️ **Keyboard Shortcuts** - ⌘N for new scan, Delete to remove files, ⌘Z to undo
+- ♿ **Accessible** - Full VoiceOver support, Full Keyboard Access, and Reduce Motion honored throughout
 - 🔒 **Privacy First** - All processing happens locally, no data leaves your Mac
 
 ## 📥 Installation

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -11,20 +11,13 @@ public enum AppConstants {
         public static let aboutDescription = "A smart duplicate photo finder for macOS"
         public static let developerName = "Akshay K Gupta"
         public static let linkedinURL = "https://www.linkedin.com/in/akshay-kr-gupta/"
-        
-        public static let exactMatchName = "Exact Match"
-        public static let exactMatchDesc = "Finds files that are bit-for-bit identical. Safe to delete any copy."
-        public static let similarMatchName = "Visual Similarity"
-        public static let similarMatchDesc = "Finds images that look similar but may have differences (size, format, edits)."
-        
+
         public static let newScan = "New Scan"
         public static let cancelScan = "Cancel Scan"
         public static let selectFolder = "Select Folder to Scan"
         public static let dragDropPrompt = "or drag and drop a folder here"
         
         public static let scanningTitle = "Scanning for Duplicates"
-        public static let exactScanProgress = "Exact Scan in Progress"
-        public static let similarScanProgress = "Similarity Scan in Progress"
         public static let scanComplete = "%d%% Complete"
         
         public static let deleteSelected = "Delete"
@@ -45,7 +38,6 @@ public enum AppConstants {
     public enum Icons {
         public static let appIcon = "photo.stack"
         public static let exactMatch = "rectangle.on.rectangle"
-        public static let similarMatch = "wand.and.stars"
         public static let folderPlus = "folder.fill.badge.plus"
         public static let checkmarkCircle = "checkmark.circle"
         public static let photoCopies = "photo.on.rectangle.angled"
@@ -53,7 +45,6 @@ public enum AppConstants {
         public static let trash = "trash"
         public static let keepShield = "shield.checkered"
         public static let eyePreview = "eye.fill"
-        public static let refresh = "arrow.top.right.and.arrow.bottom.left"
         public static let warningTriangle = "exclamationmark.triangle.fill"
     }
 
@@ -61,8 +52,6 @@ public enum AppConstants {
     public enum UI {
         public static let defaultCornerRadius: CGFloat = 16.0
         public static let cardCornerRadius: CGFloat = 20.0
-        public static let standardPadding: CGFloat = 24.0
-        public static let imageThumbnailSize: CGFloat = 160.0
     }
 
     /// Scan tuning

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -34,7 +34,7 @@ public enum AppConstants {
         public static let undoDelete = "Undo Delete"
         
         public static let noDuplicatesFound = "No Duplicates Found"
-        public static let noDuplicatesDesc = "Your folder is clean!"
+        public static let noDuplicatesDesc = "Your photo library is clean and organized"
 
         public static let userGuide = "User Guide"
 

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -35,10 +35,12 @@ public enum AppConstants {
         
         public static let noDuplicatesFound = "No Duplicates Found"
         public static let noDuplicatesDesc = "Your folder is clean!"
-        
+
         public static let userGuide = "User Guide"
+
+        public static let filesSkippedSuffix = "file(s) skipped (couldn't be read)"
     }
-    
+
     /// System Image (SF Symbols) names
     public enum Icons {
         public static let appIcon = "photo.stack"
@@ -52,13 +54,21 @@ public enum AppConstants {
         public static let keepShield = "shield.checkered"
         public static let eyePreview = "eye.fill"
         public static let refresh = "arrow.top.right.and.arrow.bottom.left"
+        public static let warningTriangle = "exclamationmark.triangle.fill"
     }
-    
+
     /// Global UI metrics
     public enum UI {
         public static let defaultCornerRadius: CGFloat = 16.0
         public static let cardCornerRadius: CGFloat = 20.0
         public static let standardPadding: CGFloat = 24.0
         public static let imageThumbnailSize: CGFloat = 160.0
+    }
+
+    /// Scan tuning
+    public enum Scan {
+        /// Feature-print distance threshold below which two images are considered visually similar.
+        /// Shared by the filesystem and Apple Photos similarity scanners so both stay in sync.
+        public static let similarityThreshold: Float = 8.0
     }
 }

--- a/Sources/TwinPixCleaner/Core/AppError.swift
+++ b/Sources/TwinPixCleaner/Core/AppError.swift
@@ -6,7 +6,11 @@ public enum AppError: Error, LocalizedError, Equatable {
     
     /// Thrown when directory traversal fails or user selects an invalid folder.
     case unreadableDirectory(URL)
-    
+
+    /// Thrown when the user drops something that isn't a folder onto the dashboard.
+    case notAFolder(URL)
+
+
     /// Thrown when an individual file deletion to the macOS Trash fails.
     case deletionFailed(URL, String)
     
@@ -15,10 +19,7 @@ public enum AppError: Error, LocalizedError, Equatable {
     
     /// Thrown when attempting to undo a deletion fails.
     case restorationFailed(URL, String)
-    
-    /// Thrown when a background scan operation is cancelled.
-    case scanCancelled
-    
+
     /// Generic unknown error fallback.
     case unknown(String)
     
@@ -26,14 +27,14 @@ public enum AppError: Error, LocalizedError, Equatable {
         switch self {
         case .unreadableDirectory(let url):
             return "Could not read the directory at \(url.path). Ensure you have necessary permissions."
+        case .notAFolder(let url):
+            return "\"\(url.lastPathComponent)\" is not a folder. Please drop a folder to scan."
         case .deletionFailed(let url, let reason):
             return "Failed to move \(url.lastPathComponent) to Trash: \(reason)"
         case .multipleDeletionsFailed(let files):
             return "Failed to delete \(files.count) file(s): \(files.joined(separator: ", "))"
         case .restorationFailed(let url, let reason):
             return "Failed to restore \(url.lastPathComponent) from Trash: \(reason)"
-        case .scanCancelled:
-            return "The scan operation was cancelled."
         case .unknown(let details):
             return "An unrecoverable error occurred: \(details)"
         }

--- a/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
@@ -8,74 +8,49 @@ import CryptoKit
 /// 3. Computes SHA-256 hashes only for files that share a size.
 /// 4. Groups by hash to return actual duplicates.
 public struct DuplicateDetector: ImageScanner {
-    
+
     public init() {}
-    
+
     public func scan(
         in directory: URL,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void = { _, _ in }
-    ) async -> [DuplicateGroup] {
-        return await Task.detached {
+    ) async throws -> ScanResult {
+        return try await Task.detached {
             // 1. Scan for files
             await onProgress(0.0, "Scanning folder…")
-            let files = FileScanner.scan(directory: directory)
-            
+            let files = try FileScanner.scan(directory: directory)
+
             if files.isEmpty {
-                return []
+                return ScanResult(groups: [], skippedCount: 0)
             }
-            
-            // 2. Group by size (fast pass — ~10% of progress)
-            var filesBySize: [Int64: [URL]] = [:]
+
+            // 2. Build candidates by size (fast pass — ~10% of progress)
+            var candidates: [(url: URL, size: Int64, label: String)] = []
+            var skipped = 0
             for (index, file) in files.enumerated() {
-                if let size = ImageHasher.getFileSize(for: file), size > 0 {
-                    filesBySize[size, default: []].append(file)
+                guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+                if let size = ImageHasher.getFileSize(for: file) {
+                    candidates.append((file, size, file.lastPathComponent))
+                } else {
+                    skipped += 1
                 }
                 if index % 50 == 0 {
                     let fraction = Double(index) / Double(files.count) * 0.1
                     await onProgress(fraction, file.lastPathComponent)
                 }
             }
-            
-            // 3. Filter groups with > 1 file
-            let potentialDuplicates = filesBySize.filter { $0.value.count > 1 }
-            
-            if potentialDuplicates.isEmpty {
-                await onProgress(1.0, "Complete")
-                return []
-            }
-            
-            var duplicates: [DuplicateGroup] = []
-            
-            // 4. Hash and group by hash (~10%–100% of progress)
-            let filesToHash = potentialDuplicates.flatMap { $0.value }
-            var hashIndex = 0
-            
-            for (size, urls) in potentialDuplicates {
-                var filesByHash: [String: [URL]] = [:]
-                
-                for url in urls {
-                    hashIndex += 1
-                    let fraction = 0.1 + (Double(hashIndex) / Double(filesToHash.count)) * 0.9
-                    await onProgress(fraction, url.lastPathComponent)
-                    
-                    if let hash = ImageHasher.computeHash(for: url) {
-                        filesByHash[hash, default: []].append(url)
-                    }
-                    
-                    // Yield periodically
-                    if hashIndex % 10 == 0 {
-                        await Task.yield()
-                    }
-                }
-                
-                // 5. Collect actual duplicates
-                for (hash, dupUrls) in filesByHash where dupUrls.count > 1 {
-                    duplicates.append(DuplicateGroup(hash: hash, fileSize: size, fileURLs: dupUrls))
-                }
-            }
-            
+
+            // 3. Group by size, then hash within each size bucket (~10%–100% of progress)
+            let result = await SizeHashGrouping.group(
+                candidates: candidates,
+                hash: { url in ImageHasher.computeHash(for: url) },
+                onProgress: onProgress,
+                baseProgress: 0.1,
+                progressSpan: 0.9
+            )
+
             await onProgress(1.0, "Complete")
-            return duplicates
+            return ScanResult(groups: result.groups, skippedCount: skipped + result.skippedCount)
         }.value
     }
 }

--- a/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Vision
+
+/// Shared "group by size, then hash within each size bucket" pipeline used by both
+/// `DuplicateDetector` (filesystem) and `PhotoLibraryScanner` (Apple Photos) exact-match scans.
+/// Callers do their own (source-specific) size lookup and hashing; this only owns the
+/// generic bucketing/grouping/progress-reporting shape so both scanners can't drift apart.
+enum SizeHashGrouping {
+    static func group(
+        candidates: [(url: URL, size: Int64, label: String)],
+        hash: @escaping @Sendable (URL) async -> String?,
+        onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
+        baseProgress: Double,
+        progressSpan: Double
+    ) async -> (groups: [DuplicateGroup], skippedCount: Int) {
+        var bySize: [Int64: [(url: URL, label: String)]] = [:]
+        for candidate in candidates where candidate.size > 0 {
+            bySize[candidate.size, default: []].append((candidate.url, candidate.label))
+        }
+
+        let potentialDuplicates = bySize.filter { $0.value.count > 1 }
+        if potentialDuplicates.isEmpty {
+            await onProgress(baseProgress + progressSpan, "Complete")
+            return ([], 0)
+        }
+
+        var groups: [DuplicateGroup] = []
+        var skipped = 0
+        let totalToHash = potentialDuplicates.values.reduce(0) { $0 + $1.count }
+        var hashedCount = 0
+
+        for (size, items) in potentialDuplicates {
+            guard !Task.isCancelled else { return (groups, skipped) }
+            var byHash: [String: [URL]] = [:]
+
+            for item in items {
+                guard !Task.isCancelled else { return (groups, skipped) }
+                hashedCount += 1
+                let fraction = baseProgress + (Double(hashedCount) / Double(totalToHash)) * progressSpan
+                await onProgress(fraction, item.label)
+
+                if let h = await hash(item.url) {
+                    byHash[h, default: []].append(item.url)
+                } else {
+                    skipped += 1
+                }
+
+                if hashedCount % 10 == 0 { await Task.yield() }
+            }
+
+            for (h, urls) in byHash where urls.count > 1 {
+                groups.append(DuplicateGroup(hash: h, fileSize: size, fileURLs: urls))
+            }
+        }
+
+        return (groups, skipped)
+    }
+}
+
+/// Shared O(n²) feature-print clustering used by both `SimilarityDetector` (filesystem)
+/// and `PhotoLibraryScanner` (Apple Photos) similarity scans: two images cluster together
+/// if their Vision feature-print distance is within `threshold`.
+enum FeaturePrintClustering {
+    static func cluster(
+        prints: [(url: URL, print: VNFeaturePrintObservation)],
+        threshold: Float,
+        onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
+        baseProgress: Double,
+        progressSpan: Double
+    ) async -> [[URL]] {
+        var groups: [[URL]] = []
+        var processedIndices = Set<Int>()
+
+        for i in 0..<prints.count {
+            guard !Task.isCancelled else { return groups }
+            if processedIndices.contains(i) { continue }
+
+            let (url1, print1) = prints[i]
+            var groupURLs = [url1]
+            processedIndices.insert(i)
+
+            for j in (i + 1)..<prints.count {
+                if processedIndices.contains(j) { continue }
+                let (url2, print2) = prints[j]
+
+                var distance: Float = 0
+                do {
+                    try print1.computeDistance(&distance, to: print2)
+                    if distance <= threshold {
+                        groupURLs.append(url2)
+                        processedIndices.insert(j)
+                    }
+                } catch {
+                    continue
+                }
+            }
+
+            if groupURLs.count > 1 {
+                groups.append(groupURLs)
+            }
+
+            if i % 10 == 0 {
+                let fraction = baseProgress + (Double(processedIndices.count) / Double(prints.count)) * progressSpan
+                await onProgress(fraction, "Clustering \(processedIndices.count)/\(prints.count)…")
+                await Task.yield()
+            }
+        }
+
+        return groups
+    }
+}

--- a/Sources/TwinPixCleaner/Core/FileDeleter.swift
+++ b/Sources/TwinPixCleaner/Core/FileDeleter.swift
@@ -72,13 +72,20 @@ struct FileDeleter {
             }
         }
         
-        // 3. Batch delete Finder Files
+        // 3. Batch delete Finder Files.
+        // Each file is trashed independently — a failure on one file must not discard the
+        // URLs that were already successfully trashed above/before it. Files missing from
+        // `results` are treated as failed deletions by the caller.
         for url in fileURLs {
-            var resultingURL: NSURL?
-            try FileManager.default.trashItem(at: url, resultingItemURL: &resultingURL)
-            results[url] = (resultingURL as URL?) ?? url
+            do {
+                var resultingURL: NSURL?
+                try FileManager.default.trashItem(at: url, resultingItemURL: &resultingURL)
+                results[url] = (resultingURL as URL?) ?? url
+            } catch {
+                continue
+            }
         }
-        
+
         return results
     }
     

--- a/Sources/TwinPixCleaner/Core/FileDeleter.swift
+++ b/Sources/TwinPixCleaner/Core/FileDeleter.swift
@@ -20,12 +20,9 @@ struct FileDeleter {
         var photoURLs: [URL] = []
         var fileURLs: [URL] = []
         
-        // 1. Separate URLs
         for url in urls {
             if url.scheme == "photos" {
-                if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                   let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-                   let localIdentifier = idItem.value {
+                if let localIdentifier = PhotosAssetURL.localIdentifier(from: url) {
                     photoLocalIdentifiers.append(localIdentifier)
                     photoURLs.append(url)
                 }
@@ -33,8 +30,9 @@ struct FileDeleter {
                 fileURLs.append(url)
             }
         }
-        
-        // 2. Batch delete Apple Photos
+
+        // Batch delete Apple Photos assets — a single performChanges call means only one
+        // permission prompt, and the change is atomic (all-or-nothing).
         if !photoLocalIdentifiers.isEmpty {
             let assets = PHAsset.fetchAssets(withLocalIdentifiers: photoLocalIdentifiers, options: nil)
             
@@ -72,8 +70,7 @@ struct FileDeleter {
             }
         }
         
-        // 3. Batch delete Finder Files.
-        // Each file is trashed independently — a failure on one file must not discard the
+        // Each Finder file is trashed independently — a failure on one file must not discard the
         // URLs that were already successfully trashed above/before it. Files missing from
         // `results` are treated as failed deletions by the caller.
         for url in fileURLs {
@@ -95,7 +92,6 @@ struct FileDeleter {
             throw NSError(domain: "FileDeleter", code: 4, userInfo: [NSLocalizedDescriptionKey: "Cannot undo Apple Photos deletion programmatically. Please restore from 'Recently Deleted' in the Photos app."])
         }
         
-        // Ensure the parent directory exists
         let parentDir = originalURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: parentDir.path) {
             try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)

--- a/Sources/TwinPixCleaner/Core/FileScanner.swift
+++ b/Sources/TwinPixCleaner/Core/FileScanner.swift
@@ -3,15 +3,15 @@ import Foundation
 struct FileScanner {
     static let imageExtensions: Set<String> = ["jpg", "jpeg", "png", "heic", "tiff", "bmp", "gif", "webp"]
 
-    static func scan(directory: URL) -> [URL] {
+    static func scan(directory: URL) throws -> [URL] {
         var fileURLs: [URL] = []
         let fileManager = FileManager.default
-        
+
         // Options for enumeration: skip hidden files, produce URLs
         let options: FileManager.DirectoryEnumerationOptions = [.skipsHiddenFiles, .skipsPackageDescendants]
-        
+
         guard let enumerator = fileManager.enumerator(at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: options) else {
-            return []
+            throw AppError.unreadableDirectory(directory)
         }
         
         for case let fileURL as URL in enumerator {

--- a/Sources/TwinPixCleaner/Core/ImageHasher.swift
+++ b/Sources/TwinPixCleaner/Core/ImageHasher.swift
@@ -3,14 +3,25 @@ import CryptoKit
 
 struct ImageHasher {
     static func computeHash(for url: URL) -> String? {
+        guard let handle = FileHandle(forReadingAtPath: url.path) else {
+            print("Error hashing file \(url.lastPathComponent): could not open for reading")
+            return nil
+        }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
         do {
-            let fileData = try Data(contentsOf: url)
-            let digest = SHA256.hash(data: fileData)
-            return digest.compactMap { String(format: "%02x", $0) }.joined()
+            // Stream in 1MB chunks instead of loading the whole file into memory.
+            while let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
         } catch {
             print("Error hashing file \(url.lastPathComponent): \(error)")
             return nil
         }
+
+        let digest = hasher.finalize()
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
     }
     
     static func getFileSize(for url: URL) -> Int64? {

--- a/Sources/TwinPixCleaner/Core/ImageScanner.swift
+++ b/Sources/TwinPixCleaner/Core/ImageScanner.swift
@@ -2,15 +2,30 @@ import Foundation
 
 /// Represents a group of mathematically or visually identical files.
 public struct DuplicateGroup: Identifiable, Hashable, Sendable {
-    public let id = UUID()
+    // Derived from `hash` (which stays stable across a group's lifetime as files are
+    // removed/restored) rather than a fresh random UUID, so SwiftUI can diff group rows
+    // in place across edits instead of treating every edit as a full row replacement.
+    public var id: String { hash }
     public let hash: String
     public let fileSize: Int64
     public let fileURLs: [URL]
-    
+
     public init(hash: String, fileSize: Int64, fileURLs: [URL]) {
         self.hash = hash
         self.fileSize = fileSize
         self.fileURLs = fileURLs
+    }
+}
+
+/// The outcome of a scan: the duplicate groups found, plus how many files were skipped
+/// because they couldn't be read/hashed/analyzed.
+public struct ScanResult: Sendable {
+    public let groups: [DuplicateGroup]
+    public let skippedCount: Int
+
+    public init(groups: [DuplicateGroup], skippedCount: Int) {
+        self.groups = groups
+        self.skippedCount = skippedCount
     }
 }
 
@@ -19,14 +34,14 @@ public struct DuplicateGroup: Identifiable, Hashable, Sendable {
 /// allowing the presentation layer (ViewModel) to consume them via Dependency Injection.
 @MainActor
 public protocol ImageScanner: Sendable {
-    
+
     /// Scans the provided directory and returns groups of duplicates.
     /// - Parameters:
     ///   - directory: The root URL to begin scanning from.
     ///   - onProgress: A callback closure returning the overall percentage (0.0 to 1.0) and current file/status string.
-    /// - Returns: An array of `DuplicateGroup`. Returning an empty array means no matches were found.
+    /// - Returns: A `ScanResult` with the duplicate groups found and how many files were skipped.
     func scan(
         in directory: URL,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
-    ) async -> [DuplicateGroup]
+    ) async throws -> ScanResult
 }

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -10,114 +10,98 @@ import AppKit
 @MainActor
 struct PhotoLibraryScanner: ImageScanner {
     let mode: ScanMode
-    
+
     init(mode: ScanMode) {
         self.mode = mode
     }
-    
+
     public func scan(
         in directory: URL,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
-    ) async -> [DuplicateGroup] {
+    ) async -> ScanResult {
         onProgress(0.0, "Requesting Photo Library Access...")
-        
+
         let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
         guard status == .authorized || status == .limited else {
             onProgress(1.0, "Access Denied")
-            return []
+            return ScanResult(groups: [], skippedCount: 0)
         }
-        
+
         onProgress(0.05, "Fetching assets...")
-        
+
         let fetchOptions = PHFetchOptions()
         fetchOptions.includeHiddenAssets = false
         let assets = PHAsset.fetchAssets(with: .image, options: fetchOptions)
-        
+
         let totalCount = assets.count
-        if totalCount == 0 { return [] }
-        
+        if totalCount == 0 { return ScanResult(groups: [], skippedCount: 0) }
+
         if mode == .exact {
             return await scanExact(assets: assets, totalCount: totalCount, onProgress: onProgress)
         } else {
             return await scanSimilar(assets: assets, totalCount: totalCount, onProgress: onProgress)
         }
     }
-    
+
     // MARK: - Exact Match Scanning
-    
+
     private func scanExact(
         assets: PHFetchResult<PHAsset>,
         totalCount: Int,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
-    ) async -> [DuplicateGroup] {
-        var assetsBySize: [Int64: [PHAsset]] = [:]
-        
-        // 1. Group by file size — skip iCloud-only assets that have no local resource
+    ) async -> ScanResult {
+        var candidates: [(url: URL, size: Int64, label: String)] = []
+        var skipped = 0
+
+        // 1. Build candidates by file size — skip iCloud-only assets that have no local resource
         for i in 0..<totalCount {
-            guard !Task.isCancelled else { return [] }
-            
+            guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+
             let asset = assets.object(at: i)
             let resources = PHAssetResource.assetResources(for: asset)
-            
+
             if let resource = resources.first(where: { $0.type == .photo }) {
                 let size = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
                 if size > 0 {
-                    assetsBySize[size, default: []].append(asset)
+                    let url = buildPhotoURL(for: asset.localIdentifier)
+                    candidates.append((url, size, resource.originalFilename))
                 }
+            } else {
+                skipped += 1
             }
-            
+
             if i % 100 == 0 {
                 let fraction = 0.05 + (Double(i) / Double(totalCount) * 0.1)
                 onProgress(fraction, "Grouping by size: \(i)/\(totalCount)")
                 await Task.yield()
             }
         }
-        
-        let potentialDuplicates = assetsBySize.filter { $0.value.count > 1 }
-        
-        if potentialDuplicates.isEmpty {
-            onProgress(1.0, "Complete")
-            return []
-        }
-        
-        // 2. Hash using raw file bytes via PHAssetResourceManager (NOT decoded image data)
-        var duplicates: [DuplicateGroup] = []
-        let totalToHash = potentialDuplicates.values.map { $0.count }.reduce(0, +)
-        var hashedCount = 0
-        
-        for (size, assetGroup) in potentialDuplicates {
-            guard !Task.isCancelled else { return [] }
-            var assetsByHash: [String: [URL]] = [:]
-            
-            for asset in assetGroup {
-                guard !Task.isCancelled else { return [] }
-                hashedCount += 1
-                let fraction = 0.15 + (Double(hashedCount) / Double(totalToHash) * 0.85)
-                onProgress(fraction, "Hashing asset \(hashedCount)/\(totalToHash)")
-                
-                if let hash = await computeHash(for: asset) {
-                    let url = buildPhotoURL(for: asset.localIdentifier)
-                    assetsByHash[hash, default: []].append(url)
-                }
-            }
-            
-            for (hash, urls) in assetsByHash where urls.count > 1 {
-                duplicates.append(DuplicateGroup(hash: hash, fileSize: size, fileURLs: urls))
-            }
-        }
-        
+
+        // 2. Group by size, then hash the raw stored bytes within each size bucket.
+        // PHAsset isn't Sendable, so the hash closure re-resolves the asset from the
+        // (Sendable) photos:// URL instead of capturing PHAsset objects across the boundary.
+        let result = await SizeHashGrouping.group(
+            candidates: candidates,
+            hash: { url in await self.computeHash(forPhotoURL: url) },
+            onProgress: onProgress,
+            baseProgress: 0.15,
+            progressSpan: 0.85
+        )
+
         onProgress(1.0, "Complete")
-        return duplicates
+        return ScanResult(groups: result.groups, skippedCount: skipped + result.skippedCount)
     }
-    
+
     // MARK: - Visual Similarity Scanning
-    
+
     private func scanSimilar(
         assets: PHFetchResult<PHAsset>,
         totalCount: Int,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
-    ) async -> [DuplicateGroup] {
-        var prints: [(url: URL, print: VNFeaturePrintObservation, size: Int64)] = []
+    ) async -> ScanResult {
+        var prints: [(url: URL, print: VNFeaturePrintObservation)] = []
+        var sizeByURL: [URL: Int64] = [:]
+        var skipped = 0
         let imageManager = PHImageManager.default()
         let requestOptions = PHImageRequestOptions()
         requestOptions.isSynchronous = false
@@ -125,22 +109,22 @@ struct PhotoLibraryScanner: ImageScanner {
         requestOptions.resizeMode = .fast
         // FIX: Do not silently download iCloud-only assets
         requestOptions.isNetworkAccessAllowed = false
-        
+
         let targetSize = CGSize(width: 256, height: 256)
-        
+
         for i in 0..<totalCount {
-            guard !Task.isCancelled else { return [] }
-            
+            guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+
             let asset = assets.object(at: i)
-            
+
             var fileSize: Int64 = 0
             if let resource = PHAssetResource.assetResources(for: asset).first(where: { $0.type == .photo }) {
                 fileSize = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
             }
-            
+
             let fraction = 0.05 + (Double(i) / Double(totalCount) * 0.4)
             onProgress(fraction, "Analyzing visually: \(i)/\(totalCount)")
-            
+
             let cgImage = await withCheckedContinuation { continuation in
                 imageManager.requestImage(
                     for: asset, targetSize: targetSize, contentMode: .aspectFit, options: requestOptions
@@ -154,74 +138,55 @@ struct PhotoLibraryScanner: ImageScanner {
                     continuation.resume(returning: image?.cgImage(forProposedRect: nil, context: nil, hints: nil))
                 }
             }
-            
+
             if let cgImage = cgImage {
                 let request = VNGenerateImageFeaturePrintRequest()
                 request.revision = VNGenerateImageFeaturePrintRequestRevision1
                 let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-                
+
                 do {
                     try handler.perform([request])
                     if let featurePrint = request.results?.first as? VNFeaturePrintObservation {
                         let url = buildPhotoURL(for: asset.localIdentifier)
-                        prints.append((url: url, print: featurePrint, size: fileSize))
+                        prints.append((url: url, print: featurePrint))
+                        sizeByURL[url] = fileSize
+                    } else {
+                        skipped += 1
                     }
                 } catch {
                     print("Failed to compute print for \(asset.localIdentifier)")
+                    skipped += 1
                 }
+            } else {
+                skipped += 1
             }
-            
+
             if i % 10 == 0 { await Task.yield() }
         }
-        
+
         onProgress(0.5, "Comparing images...")
-        
-        var duplicates: [DuplicateGroup] = []
-        var processedIndices = Set<Int>()
-        let threshold: Float = 8.0
-        
-        for i in 0..<prints.count {
-            guard !Task.isCancelled else { return [] }
-            if processedIndices.contains(i) { continue }
-            
-            let featureA = prints[i]
-            var groupURLs = [featureA.url]
-            processedIndices.insert(i)
-            
-            for j in (i + 1)..<prints.count {
-                if processedIndices.contains(j) { continue }
-                let featureB = prints[j]
-                var distance: Float = 0
-                do {
-                    try featureA.print.computeDistance(&distance, to: featureB.print)
-                    if distance <= threshold {
-                        groupURLs.append(featureB.url)
-                        processedIndices.insert(j)
-                    }
-                } catch { continue }
-            }
-            
-            if groupURLs.count > 1 {
-                duplicates.append(DuplicateGroup(
-                    hash: "visual-\(UUID().uuidString)",
-                    fileSize: featureA.size,
-                    fileURLs: groupURLs
-                ))
-            }
-            
-            if i % 50 == 0 {
-                let fraction = 0.5 + (Double(i) / Double(prints.count) * 0.5)
-                onProgress(fraction, "Grouping similar matches...")
-                await Task.yield()
-            }
+
+        let threshold = AppConstants.Scan.similarityThreshold
+        let clusters = await FeaturePrintClustering.cluster(
+            prints: prints,
+            threshold: threshold,
+            onProgress: onProgress,
+            baseProgress: 0.5,
+            progressSpan: 0.5
+        )
+
+        let groups = clusters.map { urls -> DuplicateGroup in
+            DuplicateGroup(
+                hash: "visual-\(UUID().uuidString)",
+                fileSize: sizeByURL[urls[0]] ?? 0,
+                fileURLs: urls
+            )
         }
-        
+
         onProgress(1.0, "Complete")
-        return duplicates
+        return ScanResult(groups: groups, skippedCount: skipped)
     }
-    
-    
-    
+
     /// Hashes the raw stored bytes of the photo asset file using PHAssetResourceManager.
     /// This reads the actual file bytes — NOT decoded/transcoded image data — producing
     /// a stable SHA-256 that reliably identifies bit-for-bit identical photos.
@@ -230,22 +195,36 @@ struct PhotoLibraryScanner: ImageScanner {
     /// com.apple.photos.assetResources.fileIO (a background queue). If this method were
     /// @MainActor-isolated, Swift would inject a queue assertion into the closure that
     /// would trap (EXC_BREAKPOINT / dispatch_assert_queue_fail).
+    /// Resolves the `PHAsset` from its `photos://` URL and hashes it. Exists so the hash
+    /// closure passed into `SizeHashGrouping.group` only needs to send a `URL` (Sendable)
+    /// across the boundary rather than a `PHAsset` (not Sendable).
+    nonisolated private func computeHash(forPhotoURL url: URL) async -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
+              let localIdentifier = idItem.value else {
+            return nil
+        }
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
+        guard let asset = assets.firstObject else { return nil }
+        return await computeHash(for: asset)
+    }
+
     nonisolated private func computeHash(for asset: PHAsset) async -> String? {
         guard let resource = PHAssetResource.assetResources(for: asset)
             .first(where: { $0.type == .photo }) else {
             return nil
         }
-        
+
         let options = PHAssetResourceRequestOptions()
         // Never trigger iCloud downloads during a scan
         options.isNetworkAccessAllowed = false
-        
+
         // Use a class to accumulate streaming chunks across two closures
         final class DataAccumulator: @unchecked Sendable {
             var chunks: [Data] = []
         }
         let accumulator = DataAccumulator()
-        
+
         return await withCheckedContinuation { continuation in
             PHAssetResourceManager.default().requestData(
                 for: resource,
@@ -270,12 +249,15 @@ struct PhotoLibraryScanner: ImageScanner {
             )
         }
     }
-    
+
     nonisolated private func buildPhotoURL(for localIdentifier: String) -> URL {
         var components = URLComponents()
         components.scheme = "photos"
         components.host = "asset"
         components.queryItems = [URLQueryItem(name: "id", value: localIdentifier)]
-        return components.url!
+        // Fallback is a static, always-valid literal — the dynamic localIdentifier is the
+        // only part that could theoretically fail percent-encoding, so this never masks a
+        // real per-asset failure, it just avoids a force-unwrap crash if it ever did.
+        return components.url ?? URL(string: "photos://asset")!
     }
 }

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -63,7 +63,7 @@ struct PhotoLibraryScanner: ImageScanner {
             if let resource = resources.first(where: { $0.type == .photo }) {
                 let size = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
                 if size > 0 {
-                    let url = buildPhotoURL(for: asset.localIdentifier)
+                    let url = PhotosAssetURL.build(for: asset.localIdentifier)
                     candidates.append((url, size, resource.originalFilename))
                 }
             } else {
@@ -147,7 +147,7 @@ struct PhotoLibraryScanner: ImageScanner {
                 do {
                     try handler.perform([request])
                     if let featurePrint = request.results?.first as? VNFeaturePrintObservation {
-                        let url = buildPhotoURL(for: asset.localIdentifier)
+                        let url = PhotosAssetURL.build(for: asset.localIdentifier)
                         prints.append((url: url, print: featurePrint))
                         sizeByURL[url] = fileSize
                     } else {
@@ -199,13 +199,7 @@ struct PhotoLibraryScanner: ImageScanner {
     /// closure passed into `SizeHashGrouping.group` only needs to send a `URL` (Sendable)
     /// across the boundary rather than a `PHAsset` (not Sendable).
     nonisolated private func computeHash(forPhotoURL url: URL) async -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-              let localIdentifier = idItem.value else {
-            return nil
-        }
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
-        guard let asset = assets.firstObject else { return nil }
+        guard let asset = PhotosAssetURL.asset(from: url) else { return nil }
         return await computeHash(for: asset)
     }
 
@@ -248,16 +242,5 @@ struct PhotoLibraryScanner: ImageScanner {
                 }
             )
         }
-    }
-
-    nonisolated private func buildPhotoURL(for localIdentifier: String) -> URL {
-        var components = URLComponents()
-        components.scheme = "photos"
-        components.host = "asset"
-        components.queryItems = [URLQueryItem(name: "id", value: localIdentifier)]
-        // Fallback is a static, always-valid literal — the dynamic localIdentifier is the
-        // only part that could theoretically fail percent-encoding, so this never masks a
-        // real per-asset failure, it just avoids a force-unwrap crash if it ever did.
-        return components.url ?? URL(string: "photos://asset")!
     }
 }

--- a/Sources/TwinPixCleaner/Core/PhotosAssetURL.swift
+++ b/Sources/TwinPixCleaner/Core/PhotosAssetURL.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Photos
+
+/// A `photos://asset?id=…` URL is how this app represents a `PHAsset` wherever a
+/// filesystem `URL` is otherwise expected (see `CLAUDE.md`). Building and parsing that
+/// URL was previously copy-pasted at every call site that needed to go from one
+/// representation to the other; this centralizes it.
+enum PhotosAssetURL {
+    static func build(for localIdentifier: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "photos"
+        components.host = "asset"
+        components.queryItems = [URLQueryItem(name: "id", value: localIdentifier)]
+        // Fallback is a static, always-valid literal — the dynamic localIdentifier is the
+        // only part that could theoretically fail percent-encoding, so this never masks a
+        // real per-asset failure, it just avoids a force-unwrap crash if it ever did.
+        return components.url ?? URL(string: "photos://asset")!
+    }
+
+    static func localIdentifier(from url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let idItem = components.queryItems?.first(where: { $0.name == "id" }) else {
+            return nil
+        }
+        return idItem.value
+    }
+
+    static func asset(from url: URL) -> PHAsset? {
+        guard let localIdentifier = localIdentifier(from: url) else { return nil }
+        return PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil).firstObject
+    }
+}

--- a/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
+++ b/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
@@ -5,25 +5,25 @@ import AppKit
 /// `SimilarityDetector` implements `ImageScanner` to find visually similar, but not identical, images.
 /// It uses Apple's Vision framework to compute ML feature prints and groups images based on a distance threshold.
 public struct SimilarityDetector: ImageScanner {
-    
+
     /// Distance threshold determining how "different" images can be to still be considered similar.
     /// A typical value is 8.0 to 15.0 for moderate similarity.
     public let threshold: Float
-    
-    public init(threshold: Float = 8.0) {
+
+    public init(threshold: Float = AppConstants.Scan.similarityThreshold) {
         self.threshold = threshold
     }
-    
+
     nonisolated private func computeFeaturePrint(for url: URL) -> VNFeaturePrintObservation? {
         autoreleasepool {
             guard let image = NSImage(contentsOf: url),
                   let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
                 return nil
             }
-            
+
             let request = VNGenerateImageFeaturePrintRequest()
             request.revision = VNGenerateImageFeaturePrintRequestRevision1
-            
+
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
             do {
                 try handler.perform([request])
@@ -34,103 +34,74 @@ public struct SimilarityDetector: ImageScanner {
             }
         }
     }
-    
+
     public func scan(
         in directory: URL,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void = { _, _ in }
-    ) async -> [DuplicateGroup] {
-        return await Task.detached {
+    ) async throws -> ScanResult {
+        return try await Task.detached {
             await onProgress(0.0, "Scanning folder…")
-            let files = FileScanner.scan(directory: directory)
-            if files.isEmpty { return [] }
-            
+            let files = try FileScanner.scan(directory: directory)
+            if files.isEmpty { return ScanResult(groups: [], skippedCount: 0) }
+
             // Limit to prevent crashes with large libraries
             let maxFiles = 500
             let filesToProcess = files.count > maxFiles ? Array(files.prefix(maxFiles)) : files
-            
-            var prints: [(URL, VNFeaturePrintObservation)] = []
-            
+
+            var prints: [(url: URL, print: VNFeaturePrintObservation)] = []
+            var skipped = 0
+
             // 1. Compute feature prints in batches (~0–80% of progress)
             let batchSize = 50
             var processedCount = 0
-            
+
             for batchStart in stride(from: 0, to: filesToProcess.count, by: batchSize) {
+                guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
                 let batchEnd = min(batchStart + batchSize, filesToProcess.count)
                 let batch = Array(filesToProcess[batchStart..<batchEnd])
-                
+
                 for file in batch {
                     processedCount += 1
                     let fraction = Double(processedCount) / Double(filesToProcess.count) * 0.8
                     await onProgress(fraction, file.lastPathComponent)
-                    
+
                     autoreleasepool {
                         if let print = computeFeaturePrint(for: file) {
                             prints.append((file, print))
+                        } else {
+                            skipped += 1
                         }
                     }
                 }
-                
+
                 // Yield to prevent blocking
                 await Task.yield()
             }
-            
-            if prints.isEmpty { return [] }
-            
-            var groups: [DuplicateGroup] = []
-            var processedIndices = Set<Int>()
-            
+
+            if prints.isEmpty { return ScanResult(groups: [], skippedCount: skipped) }
+
             // 2. Cluster images (~80–100% of progress)
             await onProgress(0.8, "Comparing images…")
-            
-            for i in 0..<prints.count {
-                if processedIndices.contains(i) { continue }
-                
-                let (url1, print1) = prints[i]
-                var groupURLs = [url1]
-                processedIndices.insert(i)
-                
-                // Only compare with remaining unprocessed images
-                for j in (i+1)..<prints.count {
-                    if processedIndices.contains(j) { continue }
-                    
-                    let (url2, print2) = prints[j]
-                    
-                    var distance: Float = 0
-                    do {
-                        try print1.computeDistance(&distance, to: print2)
-                        // Threshold 8.0 is moderate - finds similar but not too loose
-                        if distance <= threshold {
-                            groupURLs.append(url2)
-                            processedIndices.insert(j)
-                        }
-                    } catch {
-                        // Skip on error rather than crash
-                        continue
-                    }
-                }
-                
-                if groupURLs.count > 1 {
-                    // Calculate average size for display
-                    let totalSize = groupURLs.reduce(0) { $0 + (ImageHasher.getFileSize(for: $1) ?? 0) }
-                    let avgSize = totalSize / Int64(groupURLs.count)
-                    
-                    groups.append(DuplicateGroup(
-                        hash: "SIMILAR-" + UUID().uuidString,
-                        fileSize: avgSize,
-                        fileURLs: groupURLs
-                    ))
-                }
-                
-                // Report clustering progress and yield periodically
-                if i % 10 == 0 {
-                    let fraction = 0.8 + (Double(processedIndices.count) / Double(prints.count)) * 0.2
-                    await onProgress(fraction, "Clustering \(processedIndices.count)/\(prints.count)…")
-                    await Task.yield()
-                }
+            let clusters = await FeaturePrintClustering.cluster(
+                prints: prints,
+                threshold: threshold,
+                onProgress: onProgress,
+                baseProgress: 0.8,
+                progressSpan: 0.2
+            )
+
+            let groups = clusters.map { urls -> DuplicateGroup in
+                let totalSize = urls.reduce(0) { $0 + (ImageHasher.getFileSize(for: $1) ?? 0) }
+                let avgSize = totalSize / Int64(urls.count)
+                return DuplicateGroup(
+                    hash: "SIMILAR-" + UUID().uuidString,
+                    fileSize: avgSize,
+                    fileURLs: urls
+                )
             }
-            
+
             await onProgress(1.0, "Complete")
-            return groups
+            return ScanResult(groups: groups, skippedCount: skipped)
         }.value
     }
 }

--- a/Sources/TwinPixCleaner/UI/AppIconLoader.swift
+++ b/Sources/TwinPixCleaner/UI/AppIconLoader.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+/// Loads the app icon for display inside the UI (distinct from the .icns bundle icon).
+/// Shared by `DashboardView` and `ResultsView`, which both show it in their headers.
+func loadAppIcon() -> NSImage? {
+    // Try loading from named asset (works in development with swift run)
+    if let image = NSImage(named: "AppIcon") {
+        return image
+    }
+
+    // Try loading from resource bundle (works in packaged .app)
+    if let resourceBundle = Bundle.main.url(forResource: "TwinPixCleaner_TwinPixCleaner", withExtension: "bundle"),
+       let bundle = Bundle(url: resourceBundle),
+       let imagePath = bundle.path(forResource: "AppIcon", ofType: "png"),
+       let image = NSImage(contentsOfFile: imagePath) {
+        return image
+    }
+
+    return nil
+}

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -131,8 +131,9 @@ class AppViewModel: ObservableObject {
     func cancelScanning() {
         scanTask?.cancel()
         scanTask = nil
+        // No appError here: cancelling is a routine, user-initiated action, not a failure —
+        // popping the generic "Error" alert for it would be misleading.
         state = .idle
-        appError = .scanCancelled
     }
     
     func reset() {

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -44,6 +44,7 @@ class AppViewModel: ObservableObject {
 
     private var scanTask: Task<Void, Never>?
     private var undoToastDismissTask: Task<Void, Never>?
+    private var metadataCache: [URL: String] = [:]
     
     func startScanning(directory: URL) {
         state = .scanning
@@ -144,6 +145,7 @@ class AppViewModel: ObservableObject {
         duplicateCount = 0
         selectedFiles.removeAll()
         lastScanSkippedCount = 0
+        metadataCache.removeAll()
     }
     
     /// Selects all files in a group except the given one (the one to keep).
@@ -323,7 +325,17 @@ class AppViewModel: ObservableObject {
         quickLookCoordinator.toggle(urls: urls, at: index)
     }
     
+    /// Metadata is read from disk/PhotoKit and is otherwise recomputed on every view-body
+    /// re-evaluation (e.g. every selection change) since callers use this as a plain
+    /// computed value — cache it per URL, since it doesn't change within a scan session.
     func getFileMetadata(url: URL) -> String {
+        if let cached = metadataCache[url] { return cached }
+        let info = computeFileMetadata(url: url)
+        metadataCache[url] = info
+        return info
+    }
+
+    private func computeFileMetadata(url: URL) -> String {
         if url.scheme == "photos" {
             guard let asset = PhotosAssetURL.asset(from: url) else { return "Unknown Asset" }
 

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -290,15 +290,9 @@ class AppViewModel: ObservableObject {
     
     func getFileMetadata(url: URL) -> String {
         if url.scheme == "photos" {
-            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                  let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-                  let localIdentifier = idItem.value else {
-                return "Photo Asset"
-            }
-            
-            let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
-            guard let asset = assets.firstObject else { return "Unknown Asset" }
-            
+            guard let asset = PhotosAssetURL.asset(from: url) else { return "Unknown Asset" }
+
+
             let resources = PHAssetResource.assetResources(for: asset)
             let photoResource = resources.first { $0.type == .photo }
             let filename = photoResource?.originalFilename ?? "Photo Asset"

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -3,21 +3,12 @@ import Combine
 import Quartz
 import Photos
 
+// Synthesized Equatable: DuplicateGroup is itself Equatable, so `.results` compares the
+// actual groups instead of always reporting equal regardless of content.
 enum AppState: Equatable {
     case idle
     case scanning
     case results([DuplicateGroup])
-    
-    static func == (lhs: AppState, rhs: AppState) -> Bool {
-        switch (lhs, rhs) {
-        case (.idle, .idle), (.scanning, .scanning):
-            return true
-        case (.results, .results):
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 enum ScanMode: String, CaseIterable, Identifiable {
@@ -37,6 +28,7 @@ class AppViewModel: ObservableObject {
     
     @Published var scanMode: ScanMode = .exact
     @Published var showUserGuide: Bool = false
+    @Published var lastScanSkippedCount: Int = 0
     
     // Quick Look
     let quickLookCoordinator = QuickLookCoordinator()
@@ -59,27 +51,30 @@ class AppViewModel: ObservableObject {
         scanProgress = 0.0
         currentFile = ""
         appError = nil
-        
+        lastScanSkippedCount = 0
+
         let mode = scanMode
-        
+
         scanTask = Task { @MainActor in
-            let duplicates: [DuplicateGroup]
-            
             let progressHandler: @MainActor @Sendable (Double, String) -> Void = { progress, file in
                 self.scanProgress = progress
                 self.currentFile = file
             }
-            
-            let scanner: any ImageScanner = mode == .exact ? DuplicateDetector() : SimilarityDetector(threshold: 8.0)
-            
-            duplicates = await scanner.scan(
-                in: directory,
-                onProgress: progressHandler
-            )
-            
-            if !Task.isCancelled {
-                self.state = .results(duplicates)
-                self.duplicateCount = duplicates.count
+
+            let scanner: any ImageScanner = mode == .exact ? DuplicateDetector() : SimilarityDetector()
+
+            do {
+                let result = try await scanner.scan(in: directory, onProgress: progressHandler)
+                if !Task.isCancelled {
+                    self.state = .results(result.groups)
+                    self.duplicateCount = result.groups.count
+                    self.lastScanSkippedCount = result.skippedCount
+                }
+            } catch {
+                if !Task.isCancelled {
+                    self.appError = (error as? AppError) ?? .unknown(error.localizedDescription)
+                    self.state = .idle
+                }
             }
         }
     }
@@ -97,35 +92,39 @@ class AppViewModel: ObservableObject {
         scanProgress = 0.0
         currentFile = ""
         appError = nil
-        
+        lastScanSkippedCount = 0
+
         let mode = scanMode
-        
+
         scanTask = Task { @MainActor in
-            let duplicates: [DuplicateGroup]
-            
             let progressHandler: @MainActor @Sendable (Double, String) -> Void = { progress, file in
                 self.scanProgress = progress
                 self.currentFile = file
             }
-            
+
             let scanner: any ImageScanner = PhotoLibraryScanner(mode: mode)
-            
+
             // For photos, the directory URL doesn't matter
             let dummyURL = URL(string: "photos://library")!
-            duplicates = await scanner.scan(
-                in: dummyURL,
-                onProgress: progressHandler
-            )
-            
-            if !Task.isCancelled {
-                // If it returns empty but we have an error (e.g. prompt was just denied)
-                let finalStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-                if finalStatus == .restricted || finalStatus == .denied {
-                    self.appError = .unknown("Apple Photos access was denied. Please run the compiled TwinPixCleaner.app bundle and grant permission.")
+
+            do {
+                let result = try await scanner.scan(in: dummyURL, onProgress: progressHandler)
+                if !Task.isCancelled {
+                    // If it returns empty but we have an error (e.g. prompt was just denied)
+                    let finalStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+                    if finalStatus == .restricted || finalStatus == .denied {
+                        self.appError = .unknown("Apple Photos access was denied. Please run the compiled TwinPixCleaner.app bundle and grant permission.")
+                        self.state = .idle
+                    } else {
+                        self.state = .results(result.groups)
+                        self.duplicateCount = result.groups.count
+                        self.lastScanSkippedCount = result.skippedCount
+                    }
+                }
+            } catch {
+                if !Task.isCancelled {
+                    self.appError = (error as? AppError) ?? .unknown(error.localizedDescription)
                     self.state = .idle
-                } else {
-                    self.state = .results(duplicates)
-                    self.duplicateCount = duplicates.count
                 }
             }
         }
@@ -142,6 +141,7 @@ class AppViewModel: ObservableObject {
         state = .idle
         duplicateCount = 0
         selectedFiles.removeAll()
+        lastScanSkippedCount = 0
     }
     
     /// Selects all files in a group except the given one (the one to keep).

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -39,8 +39,11 @@ class AppViewModel: ObservableObject {
         let groupFileSize: Int64
     }
     @Published var deletionHistory: [DeletedFileRecord] = []
-    
+    @Published var showUndoToast: Bool = false
+    @Published var lastDeletionCount: Int = 0
+
     private var scanTask: Task<Void, Never>?
+    private var undoToastDismissTask: Task<Void, Never>?
     
     func startScanning(directory: URL) {
         state = .scanning
@@ -168,13 +171,14 @@ class AppViewModel: ObservableObject {
     
     func deleteSelectedFiles() {
         guard case .results(var groups) = state else { return }
-        
+
         var failedDeletions: [String] = []
+        var deletedCount = 0
         let urlsToDelete = Array(selectedFiles)
-        
+
         do {
             let results = try FileDeleter.deleteFiles(at: urlsToDelete)
-            
+
             for url in urlsToDelete {
                 if let trashedURL = results[url] {
                     let matchingGroup = groups.first { $0.fileURLs.contains(url) }
@@ -184,6 +188,7 @@ class AppViewModel: ObservableObject {
                         groupHash: matchingGroup?.hash ?? "",
                         groupFileSize: matchingGroup?.fileSize ?? 0
                     ))
+                    deletedCount += 1
                 } else {
                     failedDeletions.append(url.lastPathComponent)
                 }
@@ -192,11 +197,11 @@ class AppViewModel: ObservableObject {
             appError = .multipleDeletionsFailed([error.localizedDescription])
             return // Stop if batch completely fails
         }
-        
+
         if !failedDeletions.isEmpty {
             appError = .multipleDeletionsFailed(failedDeletions)
         }
-        
+
         groups = groups.compactMap { group in
             let remainingURLs = group.fileURLs.filter { !selectedFiles.contains($0) }
             if remainingURLs.count > 1 {
@@ -204,14 +209,15 @@ class AppViewModel: ObservableObject {
             }
             return nil
         }
-        
+
         selectedFiles.removeAll()
         state = .results(groups)
+        presentUndoToast(count: deletedCount)
     }
-    
+
     func deleteFile(url: URL, in group: DuplicateGroup) {
         guard case .results(var groups) = state else { return }
-        
+
         do {
             let trashedURL = try FileDeleter.deleteFile(at: url)
             deletionHistory.append(DeletedFileRecord(
@@ -220,10 +226,10 @@ class AppViewModel: ObservableObject {
                 groupHash: group.hash,
                 groupFileSize: group.fileSize
             ))
-            
+
             if let index = groups.firstIndex(where: { $0.id == group.id }) {
                 let updatedURLs = groups[index].fileURLs.filter { $0 != url }
-                
+
                 if updatedURLs.count > 1 {
                     let updatedGroup = DuplicateGroup(
                         hash: groups[index].hash,
@@ -235,11 +241,37 @@ class AppViewModel: ObservableObject {
                     groups.remove(at: index)
                 }
             }
-            
+
             selectedFiles.remove(url)
             state = .results(groups)
+            presentUndoToast(count: 1)
         } catch {
             appError = .deletionFailed(url, error.localizedDescription)
+        }
+    }
+
+    /// Shows the "Moved to Trash · Undo" toast for a few seconds after a deletion.
+    /// If a toast is already showing, the new count is added to it (rather than replacing it)
+    /// so Undo still restores everything deleted while the toast has been visible.
+    private func presentUndoToast(count: Int) {
+        guard count > 0 else { return }
+        lastDeletionCount = showUndoToast ? lastDeletionCount + count : count
+        showUndoToast = true
+        undoToastDismissTask?.cancel()
+        undoToastDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(4))
+            guard let self, !Task.isCancelled else { return }
+            self.showUndoToast = false
+        }
+    }
+
+    /// Undoes every file from the deletion that triggered the current undo toast.
+    func undoLastBatch() {
+        undoToastDismissTask?.cancel()
+        showUndoToast = false
+        let count = min(lastDeletionCount, deletionHistory.count)
+        for _ in 0..<count {
+            undoLastDeletion()
         }
     }
     
@@ -247,6 +279,12 @@ class AppViewModel: ObservableObject {
     func undoLastDeletion() {
         guard let record = deletionHistory.popLast() else { return }
         guard case .results(var groups) = state else { return }
+
+        // A manual step-by-step undo invalidates the toast's "undo this whole batch" count.
+        if showUndoToast {
+            undoToastDismissTask?.cancel()
+            showUndoToast = false
+        }
         
         do {
             try FileDeleter.restoreFile(from: record.trashedURL, to: record.originalURL)

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -30,10 +30,8 @@ class AppViewModel: ObservableObject {
     @Published var showUserGuide: Bool = false
     @Published var lastScanSkippedCount: Int = 0
     
-    // Quick Look
     let quickLookCoordinator = QuickLookCoordinator()
-    
-    // Undo support
+
     struct DeletedFileRecord {
         let originalURL: URL
         let trashedURL: URL
@@ -198,7 +196,6 @@ class AppViewModel: ObservableObject {
             appError = .multipleDeletionsFailed(failedDeletions)
         }
         
-        // Update groups
         groups = groups.compactMap { group in
             let remainingURLs = group.fileURLs.filter { !selectedFiles.contains($0) }
             if remainingURLs.count > 1 {
@@ -223,7 +220,6 @@ class AppViewModel: ObservableObject {
                 groupFileSize: group.fileSize
             ))
             
-            // Update the group
             if let index = groups.firstIndex(where: { $0.id == group.id }) {
                 let updatedURLs = groups[index].fileURLs.filter { $0 != url }
                 

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -3,182 +3,14 @@ import SwiftUI
 struct DashboardView: View {
     @ObservedObject var viewModel: AppViewModel
     @State private var isTargeted = false
-    
+
     var body: some View {
         VStack(spacing: 16) {
-            // Logo and Title
-            VStack(spacing: 12) {
-                if let iconImage = loadAppIcon() {
-                    Image(nsImage: iconImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 96, height: 96)
-                        .shadow(radius: 8)
-                } else {
-                    // Fallback to SF Symbol if icon not found
-                    Image(systemName: AppConstants.Icons.appIcon)
-                        .font(.system(size: 72))
-                        .foregroundStyle(FrostTheme.accentGradient)
-                }
-                
-                Text(AppConstants.Strings.appName)
-                    .font(.system(size: 36, weight: .bold, design: .rounded))
-                    .foregroundStyle(FrostTheme.accentGradient)
-                
-                Text(AppConstants.Strings.aboutDescription)
-                    .font(.title3)
-                    .foregroundColor(.secondary)
-            }
-            
-            // About Section
-            VStack(alignment: .leading, spacing: 10) {
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Find exact duplicate images across your Mac")
-                        .font(.body)
-                }
-                
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Safe deletion - files moved to Trash")
-                        .font(.body)
-                }
-                
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Multi-select for batch operations")
-                        .font(.body)
-                }
-                
-              
-            }
-            .padding(20)
-            .frostCard(cornerRadius: 20)
-            
-            // Unified Action Card
-            VStack(spacing: 20) {
-                // Scan Mode Selection
-                VStack(spacing: 10) {
-                    Picker("Scan Mode", selection: $viewModel.scanMode) {
-                        ForEach(ScanMode.allCases) { mode in
-                            Text(mode.rawValue).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 300)
-                    
-                    // Fixed-height dynamic helper text
-                    HStack(spacing: 8) {
-                        Image(systemName: viewModel.scanMode == .similar ? "sparkles" : "bolt.fill")
-                            .foregroundColor(viewModel.scanMode == .similar ? .blue : .green)
-                            .font(.system(size: 14))
-                        
-                        VStack(alignment: .leading, spacing: 2) {
-                            if viewModel.scanMode == .similar {
-                                Text("Finds visually similar images using AI.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Text("Takes extra time to process.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            } else {
-                                Text("Finds identical files using fast hashing.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Text("100% accurate and reliable.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                        .frame(height: 32, alignment: .leading)
-                        
-                        Spacer()
-                    }
-                    .padding(.horizontal, 16)
-                    .frame(width: 300)
-                }
-                
-                Divider()
-                    .frame(width: 260)
-                
-                // Action Buttons
-                VStack(spacing: 12) {
-                    Button(action: selectFolder) {
-                        Label(AppConstants.Strings.selectFolder, systemImage: AppConstants.Icons.folderPlus)
-                            .font(.headline)
-                            .padding(.vertical, 12)
-                            .padding(.horizontal, 16)
-                            .frame(width: 280)
-                    }
-                    .buttonStyle(.frostPrimary)
-                    
-                    Button(action: {
-                        viewModel.startPhotosScanning()
-                    }) {
-                        Label("Scan Apple Photos", systemImage: "photo.on.rectangle.angled")
-                            .font(.headline)
-                            .padding(.vertical, 12)
-                            .padding(.horizontal, 16)
-                            .frame(width: 280)
-                    }
-                    .buttonStyle(.frostPrimary)
-                    
-                    Text(AppConstants.Strings.dragDropPrompt)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.top, 4)
-                }
-            }
-            .padding(.vertical, 20)
-            .padding(.horizontal, 32)
-            .frostCard(cornerRadius: 24)
-            
+            logoSection
+            aboutSection
+            actionCard
             Spacer()
-            
-            // Footer with Developer Info
-            VStack(spacing: 16) {
-                HStack(spacing: 20) {
-                    ThemeToggle()
-                        .frame(width: 120)
-                        .controlSize(.small)
-                    
-                    Button(action: {
-                        viewModel.showUserGuide = true
-                    }) {
-                        Label("User Guide", systemImage: "book.fill")
-                    }
-                    .buttonStyle(.link)
-                    .controlSize(.small)
-                }
-                
-                VStack(spacing: 4) {
-                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0") • Made with ❤️ for macOS")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-                
-                HStack(spacing: 4) {
-                    Text("Developed by")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                    
-                    Button(action: {
-                        if let url = URL(string: "https://www.linkedin.com/in/akshay-kr-gupta/") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }) {
-                        Text("Akshay K Gupta")
-                            .font(.caption2)
-                            .foregroundColor(.blue)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            }
-            .padding(20)
-            .frostCard(cornerRadius: 20)
+            footerSection
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -195,18 +27,189 @@ struct DashboardView: View {
             return true
         }
     }
-    
+
+    private var logoSection: some View {
+        VStack(spacing: 12) {
+            if let iconImage = loadAppIcon() {
+                Image(nsImage: iconImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 96, height: 96)
+                    .shadow(radius: 8)
+            } else {
+                Image(systemName: AppConstants.Icons.appIcon)
+                    .font(.system(size: 72))
+                    .foregroundStyle(FrostTheme.accentGradient)
+            }
+
+            Text(AppConstants.Strings.appName)
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .foregroundStyle(FrostTheme.accentGradient)
+
+            Text(AppConstants.Strings.aboutDescription)
+                .font(.title3)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            FeatureBullet(text: "Find exact duplicate images across your Mac")
+            FeatureBullet(text: "Safe deletion - files moved to Trash")
+            FeatureBullet(text: "Multi-select for batch operations")
+        }
+        .padding(20)
+        .frostCard(cornerRadius: 20)
+    }
+
+    private var actionCard: some View {
+        VStack(spacing: 20) {
+            scanModeSection
+
+            Divider()
+                .frame(width: 260)
+
+            VStack(spacing: 12) {
+                Button(action: selectFolder) {
+                    Label(AppConstants.Strings.selectFolder, systemImage: AppConstants.Icons.folderPlus)
+                        .font(.headline)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .frame(width: 280)
+                }
+                .buttonStyle(.frostPrimary)
+
+                Button(action: {
+                    viewModel.startPhotosScanning()
+                }) {
+                    Label("Scan Apple Photos", systemImage: "photo.on.rectangle.angled")
+                        .font(.headline)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .frame(width: 280)
+                }
+                .buttonStyle(.frostPrimary)
+
+                Text(AppConstants.Strings.dragDropPrompt)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
+            }
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 32)
+        .frostCard(cornerRadius: 24)
+    }
+
+    private var scanModeSection: some View {
+        VStack(spacing: 10) {
+            Picker("Scan Mode", selection: $viewModel.scanMode) {
+                ForEach(ScanMode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 300)
+
+            // Fixed-height helper text so the layout doesn't jump when the copy changes with scanMode.
+            HStack(spacing: 8) {
+                Image(systemName: viewModel.scanMode == .similar ? "sparkles" : "bolt.fill")
+                    .foregroundColor(viewModel.scanMode == .similar ? .blue : .green)
+                    .font(.system(size: 14))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    if viewModel.scanMode == .similar {
+                        Text("Finds visually similar images using AI.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("Takes extra time to process.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Text("Finds identical files using fast hashing.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("100% accurate and reliable.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .frame(height: 32, alignment: .leading)
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .frame(width: 300)
+        }
+    }
+
+    private var footerSection: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 20) {
+                ThemeToggle()
+                    .frame(width: 120)
+                    .controlSize(.small)
+
+                Button(action: {
+                    viewModel.showUserGuide = true
+                }) {
+                    Label(AppConstants.Strings.userGuide, systemImage: "book.fill")
+                }
+                .buttonStyle(.link)
+                .controlSize(.small)
+            }
+
+            VStack(spacing: 4) {
+                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0") • Made with ❤️ for macOS")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 4) {
+                    Text("Developed by")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+
+                    Button(action: {
+                        if let url = URL(string: AppConstants.Strings.linkedinURL) {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }) {
+                        Text(AppConstants.Strings.developerName)
+                            .font(.caption2)
+                            .foregroundColor(.blue)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(20)
+        .frostCard(cornerRadius: 20)
+    }
+
     func selectFolder() {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        
+
         if panel.runModal() == .OK {
             if let url = panel.url {
                 viewModel.startScanning(directory: url)
             }
         }
     }
-    
+}
+
+/// A checkmark + text row, used by `aboutSection` to list app capabilities.
+private struct FeatureBullet: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+            Text(text)
+                .font(.body)
+        }
+    }
 }

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -39,10 +39,12 @@ struct DashboardView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 96, height: 96)
                     .shadow(radius: 8)
+                    .accessibilityHidden(true)
             } else {
                 Image(systemName: AppConstants.Icons.appIcon)
                     .font(.system(size: 72))
                     .foregroundStyle(FrostTheme.accentGradient)
+                    .accessibilityHidden(true)
             }
 
             Text(AppConstants.Strings.appName)
@@ -119,6 +121,7 @@ struct DashboardView: View {
                 Image(systemName: viewModel.scanMode == .similar ? "sparkles" : "bolt.fill")
                     .foregroundColor(viewModel.scanMode == .similar ? .blue : .green)
                     .font(.system(size: 14))
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
                     if viewModel.scanMode == .similar {
@@ -138,6 +141,7 @@ struct DashboardView: View {
                     }
                 }
                 .frame(height: 32, alignment: .leading)
+                .accessibilityElement(children: .combine)
 
                 Spacer()
             }
@@ -211,6 +215,7 @@ private struct FeatureBullet: View {
         HStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(.green)
+                .accessibilityHidden(true)
             Text(text)
                 .font(.body)
         }

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -18,9 +18,12 @@ struct DashboardView: View {
         .onDrop(of: [.fileURL], isTargeted: $isTargeted) { providers in
             guard let provider = providers.first else { return false }
             _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                if let url = url {
-                    DispatchQueue.main.async {
+                guard let url = url else { return }
+                DispatchQueue.main.async {
+                    if url.hasDirectoryPath {
                         viewModel.startScanning(directory: url)
+                    } else {
+                        viewModel.appError = .notAFolder(url)
                     }
                 }
             }

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -155,7 +155,7 @@ struct DashboardView: View {
                 }
                 
                 VStack(spacing: 4) {
-                Text("© 2026 TwinPixCleaner v2.0 • Made with ❤️ for macOS")
+                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0") • Made with ❤️ for macOS")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                 
@@ -209,20 +209,4 @@ struct DashboardView: View {
         }
     }
     
-    private func loadAppIcon() -> NSImage? {
-        // Try loading from named asset (works in development with swift run)
-        if let image = NSImage(named: "AppIcon") {
-            return image
-        }
-        
-        // Try loading from resource bundle (works in packaged .app)
-        if let resourceBundle = Bundle.main.url(forResource: "TwinPixCleaner_TwinPixCleaner", withExtension: "bundle"),
-           let bundle = Bundle(url: resourceBundle),
-           let imagePath = bundle.path(forResource: "AppIcon", ofType: "png"),
-           let image = NSImage(contentsOfFile: imagePath) {
-            return image
-        }
-        
-        return nil
-    }
 }

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -119,7 +119,7 @@ struct DashboardView: View {
             // Fixed-height helper text so the layout doesn't jump when the copy changes with scanMode.
             HStack(spacing: 8) {
                 Image(systemName: viewModel.scanMode == .similar ? "sparkles" : "bolt.fill")
-                    .foregroundColor(viewModel.scanMode == .similar ? .blue : .green)
+                    .foregroundColor(viewModel.scanMode == .similar ? FrostTheme.Colors.brand : FrostTheme.Colors.success)
                     .font(.system(size: 14))
                     .accessibilityHidden(true)
 

--- a/Sources/TwinPixCleaner/UI/DuplicateGroupRow.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateGroupRow.swift
@@ -42,27 +42,26 @@ struct DuplicateGroupRow: View {
             .background(.ultraThinMaterial)
             
             Divider()
-            
-            // Images
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
-                    ForEach(group.fileURLs, id: \.self) { url in
-                        DuplicateItemView(
-                            url: url,
-                            isSelected: viewModel.selectedFiles.contains(url),
-                            metadata: viewModel.getFileMetadata(url: url),
-                            onToggleSelection: { viewModel.toggleSelection(for: url) },
-                            onDelete: { viewModel.deleteFile(url: url, in: group) },
-                            onKeep: { viewModel.keepOnly(url, in: group) },
-                            onPreview: {
-                                let idx = group.fileURLs.firstIndex(of: url) ?? 0
-                                viewModel.toggleQuickLook(for: group.fileURLs, at: idx)
-                            }
-                        )
-                    }
+
+            // Images — an adaptive grid so sets reflow to use available window width
+            // instead of requiring horizontal scroll, and wrap into rows for larger sets.
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 12)], alignment: .leading, spacing: 12) {
+                ForEach(group.fileURLs, id: \.self) { url in
+                    DuplicateItemView(
+                        url: url,
+                        isSelected: viewModel.selectedFiles.contains(url),
+                        metadata: viewModel.getFileMetadata(url: url),
+                        onToggleSelection: { viewModel.toggleSelection(for: url) },
+                        onDelete: { viewModel.deleteFile(url: url, in: group) },
+                        onKeep: { viewModel.keepOnly(url, in: group) },
+                        onPreview: {
+                            let idx = group.fileURLs.firstIndex(of: url) ?? 0
+                            viewModel.toggleQuickLook(for: group.fileURLs, at: idx)
+                        }
+                    )
                 }
-                .padding(16)
             }
+            .padding(16)
         }
         .frostCard(cornerRadius: AppConstants.UI.cardCornerRadius)
     }

--- a/Sources/TwinPixCleaner/UI/DuplicateGroupRow.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateGroupRow.swift
@@ -10,7 +10,7 @@ struct DuplicateGroupRow: View {
             HStack(spacing: 10) {
                 Image(systemName: AppConstants.Icons.exactMatch) // Changed from square.on.square
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(FrostTheme.Colors.brand)
                 
                 Text("Duplicate Set")
                     .font(.system(size: 15, weight: .semibold))

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -8,159 +8,13 @@ struct DuplicateItemView: View {
     let onDelete: () -> Void
     let onKeep: () -> Void
     let onPreview: () -> Void
-    
+
     @State private var isHovering = false
-    
+
     var body: some View {
         VStack(spacing: 0) {
-            // Image
-            ZStack(alignment: .topTrailing) {
-                UniversalImageView(url: url)
-                    .frame(width: 200, height: 200)
-                    .clipped()
-                
-                // Selection Checkbox
-                Button(action: onToggleSelection) {
-                    ZStack {
-                        Circle()
-                            .fill(.ultraThinMaterial)
-                            .frame(width: 28, height: 28)
-                        
-                        if isSelected {
-                            Image(systemName: "checkmark.circle.fill")
-                                .font(.system(size: 20, weight: .medium))
-                                .foregroundStyle(FrostTheme.accentGradient)
-                                .symbolRenderingMode(.hierarchical)
-                        } else {
-                            Image(systemName: "circle")
-                                .font(.system(size: 20, weight: .medium))
-                                .foregroundStyle(.white)
-                                .symbolRenderingMode(.hierarchical)
-                        }
-                    }
-                    .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
-                }
-                .buttonStyle(.plain)
-                .focusable() // Enable keyboard focus
-                .padding(8)
-                
-                // Quick Look button (bottom-left on hover)
-                if isHovering {
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Button(action: onPreview) {
-                                HStack(spacing: 6) {
-                                    Image(systemName: AppConstants.Icons.eyePreview)
-                                        .font(.system(size: 12, weight: .medium))
-                                    Text("Space to Preview")
-                                        .font(.system(size: 11, weight: .medium))
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(.ultraThinMaterial)
-                                .clipShape(Capsule())
-                                .foregroundStyle(.white)
-                                .shadow(color: .black.opacity(0.3), radius: 3, y: 1)
-                            }
-                            .buttonStyle(.plain)
-                            Spacer()
-                        }
-                    }
-                    .padding(8)
-                    .transition(.opacity)
-                    .allowsHitTesting(true)
-                }
-                
-                // Hover Overlay (metadata)
-                if isHovering {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(metadata)
-                            .font(.system(size: 11, weight: .regular))
-                            .foregroundColor(.white)
-                            .lineSpacing(2)
-                            .padding(10)
-                    }
-                    .background(.ultraThickMaterial)
-                    .environment(\.colorScheme, .dark)
-                    .cornerRadius(8)
-                    .shadow(color: .black.opacity(0.3), radius: 8, y: 2)
-                    .padding(8)
-                    .frame(maxWidth: 200, alignment: .leading)
-                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                    .allowsHitTesting(false)
-                }
-            }
-            .onHover { hovering in
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    isHovering = hovering
-                }
-            }
-            .onTapGesture {
-                onToggleSelection()
-            }
-            
-            // Info Section with Better Contrast
-            VStack(spacing: 0) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(url.lastPathComponent)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    
-                    Text(url.path)
-                        .font(.system(size: 11))
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .padding(.horizontal, 12)
-                .padding(.top, 10)
-                .padding(.bottom, 8)
-                
-                Divider()
-                
-                // Action Buttons
-                HStack(spacing: 0) {
-                    // Keep This Button
-                    Button(action: onKeep) {
-                        HStack(spacing: 4) {
-                            Image(systemName: AppConstants.Icons.keepShield)
-                                .font(.system(size: 11, weight: .medium))
-                            Text(AppConstants.Strings.keepThis)
-                                .font(.system(size: 12, weight: .medium))
-                        }
-                        .foregroundColor(.indigo)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                    }
-                    .buttonStyle(.plain)
-                    .contentShape(Rectangle())
-                    
-                    Divider()
-                        .frame(height: 20)
-                    
-                    // Delete Button
-                    Button(action: onDelete) {
-                        HStack(spacing: 4) {
-                            Image(systemName: AppConstants.Icons.trash)
-                                .font(.system(size: 11, weight: .medium))
-                            Text(AppConstants.Strings.trash)
-                                .font(.system(size: 12, weight: .medium))
-                        }
-                        .foregroundColor(.red)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                    }
-                    .buttonStyle(.plain)
-                    .contentShape(Rectangle())
-                }
-            }
-            .frame(width: 200)
-            .background(.ultraThinMaterial)
+            thumbnail
+            infoSection
         }
         .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
         .background(.ultraThinMaterial)
@@ -183,5 +37,156 @@ struct DuplicateItemView: View {
         )
         .scaleEffect(isSelected ? 1.02 : 1.0)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSelected)
+    }
+
+    private var thumbnail: some View {
+        ZStack(alignment: .topTrailing) {
+            UniversalImageView(url: url)
+                .frame(width: 200, height: 200)
+                .clipped()
+
+            selectionCheckbox
+
+            if isHovering {
+                quickLookHint
+                metadataOverlay
+            }
+        }
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovering = hovering
+            }
+        }
+        .onTapGesture {
+            onToggleSelection()
+        }
+    }
+
+    private var selectionCheckbox: some View {
+        Button(action: onToggleSelection) {
+            ZStack {
+                Circle()
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 28, height: 28)
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(FrostTheme.accentGradient)
+                        .symbolRenderingMode(.hierarchical)
+                } else {
+                    Image(systemName: "circle")
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(.white)
+                        .symbolRenderingMode(.hierarchical)
+                }
+            }
+            .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
+        }
+        .buttonStyle(.plain)
+        .focusable() // Enable keyboard focus
+        .padding(8)
+    }
+
+    private var quickLookHint: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Button(action: onPreview) {
+                    HStack(spacing: 6) {
+                        Image(systemName: AppConstants.Icons.eyePreview)
+                            .font(.system(size: 12, weight: .medium))
+                        Text("Space to Preview")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Capsule())
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.3), radius: 3, y: 1)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+        }
+        .padding(8)
+        .transition(.opacity)
+        .allowsHitTesting(true)
+    }
+
+    private var metadataOverlay: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(metadata)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundColor(.white)
+                .lineSpacing(2)
+                .padding(10)
+        }
+        .background(.ultraThickMaterial)
+        .environment(\.colorScheme, .dark)
+        .cornerRadius(8)
+        .shadow(color: .black.opacity(0.3), radius: 8, y: 2)
+        .padding(8)
+        .frame(maxWidth: 200, alignment: .leading)
+        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+        .allowsHitTesting(false)
+    }
+
+    private var infoSection: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(url.lastPathComponent)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(url.path)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            HStack(spacing: 0) {
+                ActionBarButton(icon: AppConstants.Icons.keepShield, title: AppConstants.Strings.keepThis, tint: .indigo, action: onKeep)
+                Divider().frame(height: 20)
+                ActionBarButton(icon: AppConstants.Icons.trash, title: AppConstants.Strings.trash, tint: .red, action: onDelete)
+            }
+        }
+        .frame(width: 200)
+        .background(.ultraThinMaterial)
+    }
+}
+
+/// A pill-less inline action button used in the item's bottom action bar (Keep This / Delete).
+private struct ActionBarButton: View {
+    let icon: String
+    let title: String
+    let tint: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                Text(title)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundColor(tint)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
     }
 }

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -40,7 +40,15 @@ struct DuplicateItemView: View {
     }
 
     private var thumbnail: some View {
-        Button(action: onToggleSelection) {
+        Button(action: {
+            onToggleSelection()
+            // Give focus back to the window right after acting, so a focused thumbnail
+            // doesn't keep intercepting the Space key from the global Quick Look shortcut
+            // (a focused button on macOS treats Space as its own press).
+            DispatchQueue.main.async {
+                NSApp.keyWindow?.makeFirstResponder(nil)
+            }
+        }) {
             ZStack(alignment: .topTrailing) {
                 UniversalImageView(url: url)
                     .frame(width: 200, height: 200)

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -72,7 +72,7 @@ struct DuplicateItemView: View {
         Button(action: onToggleSelection) {
             ZStack {
                 Circle()
-                    .fill(.ultraThinMaterial)
+                    .fill(Color.black.opacity(0.35))
                     .frame(width: 28, height: 28)
 
                 if isSelected {
@@ -108,7 +108,7 @@ struct DuplicateItemView: View {
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
-                    .background(.ultraThinMaterial)
+                    .background(Color.black.opacity(0.55))
                     .clipShape(Capsule())
                     .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.3), radius: 3, y: 1)
@@ -166,9 +166,9 @@ struct DuplicateItemView: View {
             Divider()
 
             HStack(spacing: 0) {
-                ActionBarButton(icon: AppConstants.Icons.keepShield, title: AppConstants.Strings.keepThis, tint: .indigo, action: onKeep)
+                ActionBarButton(icon: AppConstants.Icons.keepShield, title: AppConstants.Strings.keepThis, tint: FrostTheme.Colors.brand, action: onKeep)
                 Divider().frame(height: 20)
-                ActionBarButton(icon: AppConstants.Icons.trash, title: AppConstants.Strings.trash, tint: .red, action: onDelete)
+                ActionBarButton(icon: AppConstants.Icons.trash, title: AppConstants.Strings.trash, tint: FrostTheme.Colors.destructive, action: onDelete)
             }
         }
         .frame(width: 200)

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -40,86 +40,80 @@ struct DuplicateItemView: View {
     }
 
     private var thumbnail: some View {
-        ZStack(alignment: .topTrailing) {
-            UniversalImageView(url: url)
-                .frame(width: 200, height: 200)
-                .clipped()
+        Button(action: onToggleSelection) {
+            ZStack(alignment: .topTrailing) {
+                UniversalImageView(url: url)
+                    .frame(width: 200, height: 200)
+                    .clipped()
 
-            selectionCheckbox
+                selectionCheckbox
 
-            if isHovering {
-                quickLookHint
-                metadataOverlay
+                if isHovering {
+                    quickLookHint
+                    metadataOverlay
+                }
+            }
+            .onHover { hovering in
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isHovering = hovering
+                }
             }
         }
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovering = hovering
-            }
-        }
-        .onTapGesture {
-            onToggleSelection()
-        }
-        .accessibilityElement(children: .combine)
+        .buttonStyle(.plain)
         .accessibilityLabel(url.lastPathComponent)
         .accessibilityValue(metadata)
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-        .accessibilityAction(.default) { onToggleSelection() }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityAction(named: Text("Preview")) { onPreview() }
     }
 
+    /// Purely decorative selection indicator — the whole thumbnail is the actual tap/focus
+    /// target (see `thumbnail`'s outer `Button`), so this carries no interaction of its own.
     private var selectionCheckbox: some View {
-        Button(action: onToggleSelection) {
-            ZStack {
-                Circle()
-                    .fill(Color.black.opacity(0.35))
-                    .frame(width: 28, height: 28)
+        ZStack {
+            Circle()
+                .fill(Color.black.opacity(0.35))
+                .frame(width: 28, height: 28)
 
-                if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(FrostTheme.accentGradient)
-                        .symbolRenderingMode(.hierarchical)
-                } else {
-                    Image(systemName: "circle")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(.white)
-                        .symbolRenderingMode(.hierarchical)
-                }
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(FrostTheme.accentGradient)
+                    .symbolRenderingMode(.hierarchical)
+            } else {
+                Image(systemName: "circle")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(.white)
+                    .symbolRenderingMode(.hierarchical)
             }
-            .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
         }
-        .buttonStyle(.plain)
-        .focusable() // Enable keyboard focus
+        .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
         .padding(8)
-        .accessibilityHidden(true) // toggle is exposed via the thumbnail's own accessibility action
+        .allowsHitTesting(false)
     }
 
     private var quickLookHint: some View {
         VStack {
             Spacer()
             HStack {
-                Button(action: onPreview) {
-                    HStack(spacing: 6) {
-                        Image(systemName: AppConstants.Icons.eyePreview)
-                            .font(.system(size: 12, weight: .medium))
-                        Text("Space to Preview")
-                            .font(.system(size: 11, weight: .medium))
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(Color.black.opacity(0.55))
-                    .clipShape(Capsule())
-                    .foregroundStyle(.white)
-                    .shadow(color: .black.opacity(0.3), radius: 3, y: 1)
+                HStack(spacing: 6) {
+                    Image(systemName: AppConstants.Icons.eyePreview)
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Space to Preview")
+                        .font(.system(size: 11, weight: .medium))
                 }
-                .buttonStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.black.opacity(0.55))
+                .clipShape(Capsule())
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.3), radius: 3, y: 1)
+                .contentShape(Rectangle())
+                .onTapGesture { onPreview() }
                 Spacer()
             }
         }
         .padding(8)
         .transition(.opacity)
-        .allowsHitTesting(true)
         .accessibilityHidden(true) // preview is exposed via the thumbnail's own accessibility action
     }
 

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -60,6 +60,12 @@ struct DuplicateItemView: View {
         .onTapGesture {
             onToggleSelection()
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(url.lastPathComponent)
+        .accessibilityValue(metadata)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityAction(.default) { onToggleSelection() }
+        .accessibilityAction(named: Text("Preview")) { onPreview() }
     }
 
     private var selectionCheckbox: some View {
@@ -86,6 +92,7 @@ struct DuplicateItemView: View {
         .buttonStyle(.plain)
         .focusable() // Enable keyboard focus
         .padding(8)
+        .accessibilityHidden(true) // toggle is exposed via the thumbnail's own accessibility action
     }
 
     private var quickLookHint: some View {
@@ -113,6 +120,7 @@ struct DuplicateItemView: View {
         .padding(8)
         .transition(.opacity)
         .allowsHitTesting(true)
+        .accessibilityHidden(true) // preview is exposed via the thumbnail's own accessibility action
     }
 
     private var metadataOverlay: some View {
@@ -131,6 +139,7 @@ struct DuplicateItemView: View {
         .frame(maxWidth: 200, alignment: .leading)
         .transition(.opacity.combined(with: .scale(scale: 0.95)))
         .allowsHitTesting(false)
+        .accessibilityHidden(true) // metadata is exposed via the thumbnail's accessibilityValue, not just on hover
     }
 
     private var infoSection: some View {

--- a/Sources/TwinPixCleaner/UI/FrostTheme.swift
+++ b/Sources/TwinPixCleaner/UI/FrostTheme.swift
@@ -21,8 +21,9 @@ public struct FrostTheme {
         endPoint: .bottomTrailing
     )
     
-    // Accent gradient (Indigo -> Purple)
-    public static let accentGradient = LinearGradient(
+    // Fallback accent gradient (Indigo -> Purple), used only if the system accent color
+    // can't be resolved.
+    private static let fallbackAccentGradient = LinearGradient(
         colors: [
             Color(red: 0.39, green: 0.40, blue: 0.95),   // #6366F1
             Color(red: 0.66, green: 0.33, blue: 0.97)    // #A855F7
@@ -30,6 +31,41 @@ public struct FrostTheme {
         startPoint: .leading,
         endPoint: .trailing
     )
+
+    /// The two HSB stops derived from the user's macOS accent color (System Settings ›
+    /// Appearance), reproducing the same hue-shift/saturation/brightness relationship as the
+    /// original hardcoded Indigo -> Purple pair. Returns `nil` if the system color can't be
+    /// resolved to RGB, so callers can fall back to a fixed gradient.
+    private static var accentStops: (Color, Color)? {
+        guard let rgb = NSColor.controlAccentColor.usingColorSpace(.deviceRGB) else { return nil }
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        rgb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        let s1 = max(s, 0.35) // avoid a muddy near-gray gradient for low-saturation accents (e.g. Graphite)
+        let stop1 = Color(hue: h, saturation: s1, brightness: b)
+        let stop2 = Color(
+            hue: (h + 28.0 / 360.0).truncatingRemainder(dividingBy: 1.0),
+            saturation: max(s1 - 0.08, 0.3),
+            brightness: min(b + 0.03, 1.0)
+        )
+        return (stop1, stop2)
+    }
+
+    /// Accent gradient derived from the user's system accent color. Falls back to a fixed
+    /// Indigo -> Purple gradient if the system color can't be resolved.
+    public static var accentGradient: LinearGradient {
+        guard let (stop1, stop2) = accentStops else { return fallbackAccentGradient }
+        return LinearGradient(colors: [stop1, stop2], startPoint: .leading, endPoint: .trailing)
+    }
+
+    /// Semantic color tokens built on top of the accent-derived gradient and a few
+    /// standard system colors, replacing the scattered ad-hoc tints used across the UI.
+    public enum Colors {
+        public static var brand: Color { accentStops?.0 ?? Color(red: 0.39, green: 0.40, blue: 0.95) }
+        public static var brandAlt: Color { accentStops?.1 ?? Color(red: 0.66, green: 0.33, blue: 0.97) }
+        public static let success: Color = .green
+        public static let warning: Color = .orange
+        public static let destructive: Color = .red
+    }
 }
 
 public struct FrostCardModifier: ViewModifier {

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -22,10 +22,9 @@ struct MenuCommands: Commands {
 
         CommandGroup(replacing: .help) {
             Button("TwinPixCleaner Help") {
-                if let url = URL(string: AppConstants.Strings.linkedinURL) {
-                    NSWorkspace.shared.open(url)
-                }
+                viewModel.showUserGuide = true
             }
+            .keyboardShortcut("?", modifiers: .command)
         }
 
         CommandGroup(replacing: .appInfo) {

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -4,34 +4,30 @@ struct MenuCommands: Commands {
     @ObservedObject var viewModel: AppViewModel
     
     var body: some Commands {
-        // Replace default "New" command
         CommandGroup(replacing: .newItem) {
-            Button("New Scan") {
+            Button(AppConstants.Strings.newScan) {
                 viewModel.reset()
             }
             .keyboardShortcut("n", modifiers: .command)
             .disabled(viewModel.state == .scanning)
         }
-        
-        // Undo support
+
         CommandGroup(replacing: .undoRedo) {
-            Button("Undo Delete") {
+            Button(AppConstants.Strings.undoDelete) {
                 viewModel.undoLastDeletion()
             }
             .keyboardShortcut("z", modifiers: .command)
             .disabled(!viewModel.canUndo)
         }
-        
-        // Help menu
+
         CommandGroup(replacing: .help) {
             Button("TwinPixCleaner Help") {
-                if let url = URL(string: "https://www.linkedin.com/in/akshay-kr-gupta/") {
+                if let url = URL(string: AppConstants.Strings.linkedinURL) {
                     NSWorkspace.shared.open(url)
                 }
             }
         }
-        
-        // App Info
+
         CommandGroup(replacing: .appInfo) {
             Button("About TwinPixCleaner") {
                 let info = Bundle.main.infoDictionary
@@ -39,10 +35,10 @@ struct MenuCommands: Commands {
                 let build = info?["CFBundleVersion"] as? String ?? "1"
                 NSApplication.shared.orderFrontStandardAboutPanel(
                     options: [
-                        .applicationName: "TwinPixCleaner",
+                        .applicationName: AppConstants.Strings.appName,
                         .applicationVersion: version,
                         .version: "Build \(build)",
-                        .credits: NSAttributedString(string: "Developed by Akshay K Gupta\nA smart duplicate photo finder for macOS")
+                        .credits: NSAttributedString(string: "Developed by \(AppConstants.Strings.developerName)\n\(AppConstants.Strings.aboutDescription)")
                     ]
                 )
             }

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -34,11 +34,14 @@ struct MenuCommands: Commands {
         // App Info
         CommandGroup(replacing: .appInfo) {
             Button("About TwinPixCleaner") {
+                let info = Bundle.main.infoDictionary
+                let version = info?["CFBundleShortVersionString"] as? String ?? "2.0.0"
+                let build = info?["CFBundleVersion"] as? String ?? "1"
                 NSApplication.shared.orderFrontStandardAboutPanel(
                     options: [
                         .applicationName: "TwinPixCleaner",
-                        .applicationVersion: "1.0.0",
-                        .version: "Build 1",
+                        .applicationVersion: version,
+                        .version: "Build \(build)",
                         .credits: NSAttributedString(string: "Developed by Akshay K Gupta\nA smart duplicate photo finder for macOS")
                     ]
                 )

--- a/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
+++ b/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
@@ -45,51 +45,90 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
               let localIdentifier = idItem.value else {
             return url
         }
-        
+
         let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
         guard let asset = assets.firstObject else { return url }
-        
+
         let manager = PHImageManager.default()
         let options = PHImageRequestOptions()
         options.isSynchronous = true
         options.isNetworkAccessAllowed = true
         options.deliveryMode = .highQualityFormat
-        
+
         var tempURL = url
-        
+
         manager.requestImageDataAndOrientation(for: asset, options: options) { data, dataUTI, _, _ in
-            guard let data = data else { return }
-            
-            let ext: String
-            if let uti = dataUTI {
-                if uti.contains("jpeg") { ext = "jpg" }
-                else if uti.contains("png") { ext = "png" }
-                else if uti.contains("heic") { ext = "heic" }
-                else { ext = "jpg" }
-            } else {
-                ext = "jpg"
-            }
-            
-            let tempDir = FileManager.default.temporaryDirectory
-            let fileName = UUID().uuidString + "." + ext
-            let fileURL = tempDir.appendingPathComponent(fileName)
-            
-            do {
-                // Write with atomic flag for safety
-                try data.write(to: fileURL, options: [.atomic])
-                // FIX: Restrict permissions to owner read/write only (0o600)
-                // so other processes running as the same user cannot read the exported photo.
-                try FileManager.default.setAttributes(
-                    [.posixPermissions: 0o600],
-                    ofItemAtPath: fileURL.path
-                )
-                tempURL = fileURL
-            } catch {
-                print("Failed to write temp photo for quicklook: \(error)")
+            guard let data = data, let written = self.writeTempPhoto(data: data, dataUTI: dataUTI) else { return }
+            tempURL = written
+        }
+
+        return tempURL
+    }
+
+    /// Async counterpart to `extractPhotoToTemp`, used to prefetch off the main thread
+    /// before the panel opens (see `show(urls:at:)`) so the synchronous
+    /// `QLPreviewPanelDataSource` callback doesn't have to block on an iCloud download.
+    @discardableResult
+    private func prefetchPhotoToTemp(url: URL) async -> URL? {
+        if let cached = tempPhotoURLs[url] { return cached }
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
+              let localIdentifier = idItem.value else {
+            return nil
+        }
+
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
+        guard let asset = assets.firstObject else { return nil }
+
+        let manager = PHImageManager.default()
+        let options = PHImageRequestOptions()
+        options.isSynchronous = false
+        options.isNetworkAccessAllowed = true
+        options.deliveryMode = .highQualityFormat
+
+        let result: (Data, String?)? = await withCheckedContinuation { continuation in
+            manager.requestImageDataAndOrientation(for: asset, options: options) { data, dataUTI, _, _ in
+                if let data { continuation.resume(returning: (data, dataUTI)) }
+                else { continuation.resume(returning: nil) }
             }
         }
-        
-        return tempURL
+        guard let (data, dataUTI) = result, let fileURL = writeTempPhoto(data: data, dataUTI: dataUTI) else {
+            return nil
+        }
+
+        tempPhotoURLs[url] = fileURL
+        return fileURL
+    }
+
+    private func writeTempPhoto(data: Data, dataUTI: String?) -> URL? {
+        let ext: String
+        if let uti = dataUTI {
+            if uti.contains("jpeg") { ext = "jpg" }
+            else if uti.contains("png") { ext = "png" }
+            else if uti.contains("heic") { ext = "heic" }
+            else { ext = "jpg" }
+        } else {
+            ext = "jpg"
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(UUID().uuidString + "." + ext)
+
+        do {
+            // Write with atomic flag for safety
+            try data.write(to: fileURL, options: [.atomic])
+            // Restrict permissions to owner read/write only (0o600) so other processes
+            // running as the same user cannot read the exported photo.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+            return fileURL
+        } catch {
+            print("Failed to write temp photo for quicklook: \(error)")
+            return nil
+        }
     }
     
     // MARK: - QLPreviewPanelDelegate
@@ -103,7 +142,15 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
     func show(urls: [URL], at index: Int = 0) {
         previewURLs = urls
         currentIndex = max(0, min(index, urls.count - 1))
-        
+
+        // Prefetch the initially visible photo asynchronously so the synchronous
+        // QLPreviewPanelDataSource callback below has a chance to find it already cached
+        // instead of blocking the main thread on an iCloud download.
+        if currentIndex < urls.count, urls[currentIndex].scheme == "photos" {
+            let urlToPrefetch = urls[currentIndex]
+            Task { await prefetchPhotoToTemp(url: urlToPrefetch) }
+        }
+
         if let panel = QLPreviewPanel.shared() {
             if panel.isVisible {
                 panel.reloadData()

--- a/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
+++ b/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
@@ -40,14 +40,7 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
     }
     
     private func extractPhotoToTemp(url: URL) -> URL {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-              let localIdentifier = idItem.value else {
-            return url
-        }
-
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
-        guard let asset = assets.firstObject else { return url }
+        guard let asset = PhotosAssetURL.asset(from: url) else { return url }
 
         let manager = PHImageManager.default()
         let options = PHImageRequestOptions()
@@ -71,15 +64,7 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
     @discardableResult
     private func prefetchPhotoToTemp(url: URL) async -> URL? {
         if let cached = tempPhotoURLs[url] { return cached }
-
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-              let localIdentifier = idItem.value else {
-            return nil
-        }
-
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
-        guard let asset = assets.firstObject else { return nil }
+        guard let asset = PhotosAssetURL.asset(from: url) else { return nil }
 
         let manager = PHImageManager.default()
         let options = PHImageRequestOptions()

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -12,6 +12,8 @@ struct ResultsView: View {
     let groups: [DuplicateGroup]
     @State private var sortOption: SortOption = .largestFirst
     @State private var isAnimatingCheckmark = false
+    @State private var showDeleteConfirmation = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var sortedGroups: [DuplicateGroup] {
         switch sortOption {
@@ -55,7 +57,51 @@ struct ResultsView: View {
                     footerStatsBar
                 }
             }
+
+            if viewModel.showUndoToast {
+                VStack {
+                    Spacer()
+                    undoToast
+                        .padding(.bottom, groups.isEmpty ? 24 : 84)
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
+        .animation(.easeOut(duration: 0.25), value: viewModel.showUndoToast)
+        .confirmationDialog(
+            "Move \(viewModel.selectedFiles.count) \(viewModel.selectedFiles.count == 1 ? "file" : "files") to Trash?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Move to Trash", role: .destructive) {
+                viewModel.deleteSelectedFiles()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("You can undo this immediately after.")
+        }
+    }
+
+    private var undoToast: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text("Moved \(viewModel.lastDeletionCount) \(viewModel.lastDeletionCount == 1 ? "file" : "files") to Trash")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+            Button("Undo") {
+                viewModel.undoLastBatch()
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(FrostTheme.accentGradient)
+            .fontWeight(.semibold)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.ultraThickMaterial)
+        .environment(\.colorScheme, .dark)
+        .clipShape(Capsule())
+        .shadow(color: .black.opacity(0.3), radius: 8, y: 2)
     }
 
     private var skippedFilesBanner: some View {
@@ -78,9 +124,10 @@ struct ResultsView: View {
                 .font(.system(size: 64, weight: .light))
                 .foregroundStyle(.green)
                 .symbolRenderingMode(.hierarchical)
-                .scaleEffect(isAnimatingCheckmark ? 1.0 : 0.5)
-                .opacity(isAnimatingCheckmark ? 1.0 : 0.0)
-                .animation(.spring(response: 0.6, dampingFraction: 0.5, blendDuration: 0.5).delay(0.1), value: isAnimatingCheckmark)
+                .accessibilityHidden(true)
+                .scaleEffect(reduceMotion ? 1.0 : (isAnimatingCheckmark ? 1.0 : 0.5))
+                .opacity(reduceMotion ? 1.0 : (isAnimatingCheckmark ? 1.0 : 0.0))
+                .animation(reduceMotion ? nil : .spring(response: 0.6, dampingFraction: 0.5, blendDuration: 0.5).delay(0.1), value: isAnimatingCheckmark)
                 .onAppear {
                     isAnimatingCheckmark = true
                 }
@@ -159,7 +206,7 @@ struct ResultsView: View {
                         .controlSize(.large)
 
                         Button(action: {
-                            viewModel.deleteSelectedFiles()
+                            showDeleteConfirmation = true
                         }) {
                             Label("\(AppConstants.Strings.deleteSelected) \(viewModel.selectedFiles.count)", systemImage: "trash")
                                 .font(.system(size: 13, weight: .medium))
@@ -200,7 +247,7 @@ struct ResultsView: View {
         .focusable()
         .onDeleteCommand {
             if !viewModel.selectedFiles.isEmpty {
-                viewModel.deleteSelectedFiles()
+                showDeleteConfirmation = true
             }
         }
         .onAppear {
@@ -225,6 +272,7 @@ struct ResultsView: View {
                 .keyboardShortcut(.space, modifiers: [])
                 .opacity(0)
                 .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
 
                 StatTile(icon: "square.on.square.fill", tint: .blue, value: "\(groups.count)", label: "Duplicate Groups")
 
@@ -278,6 +326,7 @@ private struct StatTile: View {
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(tint)
                 .symbolRenderingMode(.hierarchical)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(value)
@@ -287,5 +336,6 @@ private struct StatTile: View {
                     .foregroundColor(.secondary)
             }
         }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -12,7 +12,6 @@ struct ResultsView: View {
     let groups: [DuplicateGroup]
     @State private var sortOption: SortOption = .largestFirst
     @State private var isAnimatingCheckmark = false
-    @State private var showDeleteConfirmation = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var sortedGroups: [DuplicateGroup] {
@@ -68,18 +67,6 @@ struct ResultsView: View {
             }
         }
         .animation(.easeOut(duration: 0.25), value: viewModel.showUndoToast)
-        .confirmationDialog(
-            "Move \(viewModel.selectedFiles.count) \(viewModel.selectedFiles.count == 1 ? "file" : "files") to Trash?",
-            isPresented: $showDeleteConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button("Move to Trash", role: .destructive) {
-                viewModel.deleteSelectedFiles()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("You can undo this immediately after.")
-        }
     }
 
     private var undoToast: some View {
@@ -206,7 +193,7 @@ struct ResultsView: View {
                         .controlSize(.large)
 
                         Button(action: {
-                            showDeleteConfirmation = true
+                            viewModel.deleteSelectedFiles()
                         }) {
                             Label("\(AppConstants.Strings.deleteSelected) \(viewModel.selectedFiles.count)", systemImage: "trash")
                                 .font(.system(size: 13, weight: .medium))
@@ -247,7 +234,7 @@ struct ResultsView: View {
         .focusable()
         .onDeleteCommand {
             if !viewModel.selectedFiles.isEmpty {
-                showDeleteConfirmation = true
+                viewModel.deleteSelectedFiles()
             }
         }
         .onAppear {

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -12,7 +12,7 @@ struct ResultsView: View {
     let groups: [DuplicateGroup]
     @State private var sortOption: SortOption = .largestFirst
     @State private var isAnimatingCheckmark = false
-    
+
     var sortedGroups: [DuplicateGroup] {
         switch sortOption {
         case .largestFirst:
@@ -25,276 +25,267 @@ struct ResultsView: View {
             return groups.sorted { $0.fileURLs.count < $1.fileURLs.count }
         }
     }
-    
+
     var totalDuplicates: Int {
         groups.reduce(0) { $0 + $1.fileURLs.count }
     }
-    
+
     var totalSize: Int64 {
         groups.reduce(0) { $0 + (Int64($1.fileURLs.count) * $1.fileSize) }
     }
-    
+
     var potentialSavings: Int64 {
         groups.reduce(0) { total, group in
             total + (Int64(group.fileURLs.count - 1) * group.fileSize)
         }
     }
-    
+
     var body: some View {
         ZStack {
-            // Background handled by App container
-            
             VStack(spacing: 0) {
                 if viewModel.lastScanSkippedCount > 0 {
-                    HStack(spacing: 8) {
-                        Image(systemName: AppConstants.Icons.warningTriangle)
-                            .foregroundColor(.orange)
-                        Text("\(viewModel.lastScanSkippedCount) \(AppConstants.Strings.filesSkippedSuffix)")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(.secondary)
-                        Spacer()
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 8)
-                    .background(.ultraThinMaterial)
+                    skippedFilesBanner
                 }
 
                 if groups.isEmpty {
-                    VStack(spacing: 24) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 64, weight: .light))
-                            .foregroundStyle(.green)
-                            .symbolRenderingMode(.hierarchical)
-                            .scaleEffect(isAnimatingCheckmark ? 1.0 : 0.5)
-                            .opacity(isAnimatingCheckmark ? 1.0 : 0.0)
-                            .animation(.spring(response: 0.6, dampingFraction: 0.5, blendDuration: 0.5).delay(0.1), value: isAnimatingCheckmark)
-                            .onAppear {
-                                isAnimatingCheckmark = true
-                            }
-                        
-                        VStack(spacing: 8) {
-                            Text("No Duplicates Found")
-                                .font(.system(size: 28, weight: .semibold))
-                            Text("Your photo library is clean and organized")
-                                .font(.system(size: 15))
-                                .foregroundColor(.secondary)
-                        }
-                        
-                        Button("Scan Another Folder") {
-                            viewModel.reset()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
-                        .padding(.top, 8)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    emptyStateView
                 } else {
-                    // Header
-                    VStack(spacing: 0) {
-                        HStack(spacing: 16) {
-                            // Logo
-                            if let iconImage = loadAppIcon() {
-                                Image(nsImage: iconImage)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 48, height: 48)
-                                    .shadow(radius: 2)
-                            } else {
-                                // Fallback to SF Symbol
-                                Image(systemName: "photo.stack.fill")
-                                    .font(.system(size: 28, weight: .medium))
-                                    .foregroundStyle(
-                                        FrostTheme.accentGradient
-                                    )
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("TwinPixCleaner")
-                                    .font(.system(size: 22, weight: .semibold))
-                                Text("Duplicate Analysis")
-                                    .font(.system(size: 13))
-                                    .foregroundColor(.secondary)
-                            }
-                            
-                            Spacer()
-                            
-                            // Sort Picker
-                            HStack(spacing: 8) {
-                                Image(systemName: "arrow.up.arrow.down")
-                                    .font(.system(size: 12))
-                                    .foregroundColor(.secondary)
-                                
-                                Picker("Sort", selection: $sortOption) {
-                                    ForEach(SortOption.allCases, id: \.self) { option in
-                                        Text(option.rawValue).tag(option)
-                                    }
-                                }
-                                .pickerStyle(.menu)
-                                .frame(width: 150)
-                            }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial)
-                            .cornerRadius(8)
-                            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.2), lineWidth: 0.5))
-                            
-                            // Actions
-                            HStack(spacing: 12) {
-                                if !viewModel.selectedFiles.isEmpty {
-                                    Button(action: {
-                                        viewModel.selectedFiles.removeAll()
-                                    }) {
-                                        Text("Clear Selection")
-                                            .font(.system(size: 13, weight: .medium))
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.large)
-                                    
-                                    Button(action: {
-                                        viewModel.deleteSelectedFiles()
-                                    }) {
-                                        Label("Delete \(viewModel.selectedFiles.count)", systemImage: "trash")
-                                            .font(.system(size: 13, weight: .medium))
-                                            .padding(.horizontal, 16)
-                                            .padding(.vertical, 8)
-                                    }
-                                    .buttonStyle(.frostPrimary)
-                                }
-                                
-                                Button {
-                                    viewModel.reset()
-                                } label: {
-                                    Text("New Scan")
-                                        .font(.system(size: 13, weight: .medium))
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.large)
-                            }
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 16)
-                        
-                        Divider()
-                    }
-                    .background(.ultraThinMaterial)
-                    
-                    // Content
-                    ScrollView {
-                        LazyVStack(spacing: 16) {
-                            ForEach(sortedGroups) { group in
-                                DuplicateGroupRow(viewModel: viewModel, group: group)
-                            }
-                        }
-                        .padding(20)
-                        .padding(.bottom, 60) // Space for footer
-                    }
-                    .focusable()
-                    .onDeleteCommand {
-                        if !viewModel.selectedFiles.isEmpty {
-                            viewModel.deleteSelectedFiles()
-                        }
-                    }
-                    .onAppear {
-                        // Ensure the view can receive keyboard events
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            NSApp.keyWindow?.makeFirstResponder(nil)
-                        }
-                    }
-                    
-                    // Fixed Footer Bar
-                    VStack(spacing: 0) {
-                        Divider()
-                        
-                        HStack(spacing: 32) {
-                            // Hidden Button for Spacebar QuickLook
-                            Button("") {
-                                if !viewModel.selectedFiles.isEmpty {
-                                    viewModel.toggleQuickLook(for: Array(viewModel.selectedFiles))
-                                }
-                            }
-                            .keyboardShortcut(.space, modifiers: [])
-                            .opacity(0)
-                            .frame(width: 0, height: 0)
-                            
-                            // Duplicate Groups
-                            HStack(spacing: 8) {
-                                Image(systemName: "square.on.square.fill")
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundStyle(.blue)
-                                    .symbolRenderingMode(.hierarchical)
-                                
-                                VStack(alignment: .leading, spacing: 1) {
-                                    Text("\(groups.count)")
-                                        .font(.system(size: 15, weight: .semibold))
-                                    Text("Duplicate Groups")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                            
-                            Divider()
-                                .frame(height: 24)
-                            
-                            // Total Files
-                            HStack(spacing: 8) {
-                                Image(systemName: "photo.fill.on.rectangle.fill")
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundStyle(.purple)
-                                    .symbolRenderingMode(.hierarchical)
-                                
-                                VStack(alignment: .leading, spacing: 1) {
-                                    Text("\(totalDuplicates)")
-                                        .font(.system(size: 15, weight: .semibold))
-                                    Text("Total Duplicates")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                            
-                            Divider()
-                                .frame(height: 24)
-                            
-                            // Potential Savings
-                            HStack(spacing: 8) {
-                                Image(systemName: "arrow.down.circle.fill")
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundStyle(.green)
-                                    .symbolRenderingMode(.hierarchical)
-                                
-                                VStack(alignment: .leading, spacing: 1) {
-                                    Text(ByteCountFormatter.string(fromByteCount: potentialSavings, countStyle: .file))
-                                        .font(.system(size: 15, weight: .semibold))
-                                    Text("Can Be Freed")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                            
-                            Spacer()
-                            
-                            ThemeToggle()
-                                .controlSize(.mini)
-                                .frame(width: 150)
-                            
-                            // Selection Info
-                            if !viewModel.selectedFiles.isEmpty {
-                                HStack(spacing: 6) {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .font(.system(size: 12))
-                                        .foregroundStyle(.blue)
-                                    Text("\(viewModel.selectedFiles.count) selected")
-                                        .font(.system(size: 12, weight: .medium))
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 12)
-                        .background(.ultraThinMaterial)
-                    }
+                    headerBar
+                    resultsList
+                    footerStatsBar
                 }
             }
         }
     }
+
+    private var skippedFilesBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: AppConstants.Icons.warningTriangle)
+                .foregroundColor(.orange)
+            Text("\(viewModel.lastScanSkippedCount) \(AppConstants.Strings.filesSkippedSuffix)")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 64, weight: .light))
+                .foregroundStyle(.green)
+                .symbolRenderingMode(.hierarchical)
+                .scaleEffect(isAnimatingCheckmark ? 1.0 : 0.5)
+                .opacity(isAnimatingCheckmark ? 1.0 : 0.0)
+                .animation(.spring(response: 0.6, dampingFraction: 0.5, blendDuration: 0.5).delay(0.1), value: isAnimatingCheckmark)
+                .onAppear {
+                    isAnimatingCheckmark = true
+                }
+
+            VStack(spacing: 8) {
+                Text(AppConstants.Strings.noDuplicatesFound)
+                    .font(.system(size: 28, weight: .semibold))
+                Text(AppConstants.Strings.noDuplicatesDesc)
+                    .font(.system(size: 15))
+                    .foregroundColor(.secondary)
+            }
+
+            Button("Scan Another Folder") {
+                viewModel.reset()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.top, 8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var headerBar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 16) {
+                if let iconImage = loadAppIcon() {
+                    Image(nsImage: iconImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 48, height: 48)
+                        .shadow(radius: 2)
+                } else {
+                    Image(systemName: "photo.stack.fill")
+                        .font(.system(size: 28, weight: .medium))
+                        .foregroundStyle(FrostTheme.accentGradient)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("TwinPixCleaner")
+                        .font(.system(size: 22, weight: .semibold))
+                    Text("Duplicate Analysis")
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.up.arrow.down")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+
+                    Picker("Sort", selection: $sortOption) {
+                        ForEach(SortOption.allCases, id: \.self) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 150)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.ultraThinMaterial)
+                .cornerRadius(8)
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.2), lineWidth: 0.5))
+
+                HStack(spacing: 12) {
+                    if !viewModel.selectedFiles.isEmpty {
+                        Button(action: {
+                            viewModel.selectedFiles.removeAll()
+                        }) {
+                            Text("Clear Selection")
+                                .font(.system(size: 13, weight: .medium))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+
+                        Button(action: {
+                            viewModel.deleteSelectedFiles()
+                        }) {
+                            Label("\(AppConstants.Strings.deleteSelected) \(viewModel.selectedFiles.count)", systemImage: "trash")
+                                .font(.system(size: 13, weight: .medium))
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                        }
+                        .buttonStyle(.frostPrimary)
+                    }
+
+                    Button {
+                        viewModel.reset()
+                    } label: {
+                        Text(AppConstants.Strings.newScan)
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+
+            Divider()
+        }
+        .background(.ultraThinMaterial)
+    }
+
+    private var resultsList: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(sortedGroups) { group in
+                    DuplicateGroupRow(viewModel: viewModel, group: group)
+                }
+            }
+            .padding(20)
+            .padding(.bottom, 60) // Space for the fixed footer bar
+        }
+        .focusable()
+        .onDeleteCommand {
+            if !viewModel.selectedFiles.isEmpty {
+                viewModel.deleteSelectedFiles()
+            }
+        }
+        .onAppear {
+            // Ensure the view can receive keyboard events
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                NSApp.keyWindow?.makeFirstResponder(nil)
+            }
+        }
+    }
+
+    private var footerStatsBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            HStack(spacing: 32) {
+                // Invisible button so Spacebar opens Quick Look even without a visible focus target.
+                Button("") {
+                    if !viewModel.selectedFiles.isEmpty {
+                        viewModel.toggleQuickLook(for: Array(viewModel.selectedFiles))
+                    }
+                }
+                .keyboardShortcut(.space, modifiers: [])
+                .opacity(0)
+                .frame(width: 0, height: 0)
+
+                StatTile(icon: "square.on.square.fill", tint: .blue, value: "\(groups.count)", label: "Duplicate Groups")
+
+                Divider().frame(height: 24)
+
+                StatTile(icon: "photo.fill.on.rectangle.fill", tint: .purple, value: "\(totalDuplicates)", label: "Total Duplicates")
+
+                Divider().frame(height: 24)
+
+                StatTile(
+                    icon: "arrow.down.circle.fill",
+                    tint: .green,
+                    value: ByteCountFormatter.string(fromByteCount: potentialSavings, countStyle: .file),
+                    label: "Can Be Freed"
+                )
+
+                Spacer()
+
+                ThemeToggle()
+                    .controlSize(.mini)
+                    .frame(width: 150)
+
+                if !viewModel.selectedFiles.isEmpty {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.blue)
+                        Text("\(viewModel.selectedFiles.count) selected")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .background(.ultraThinMaterial)
+        }
+    }
 }
 
+/// A small icon + value + label block, used by `footerStatsBar` to show the group/file/savings counts.
+private struct StatTile: View {
+    let icon: String
+    let tint: Color
+    let value: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(tint)
+                .symbolRenderingMode(.hierarchical)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(label)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -85,7 +85,7 @@ struct ResultsView: View {
     private var undoToast: some View {
         HStack(spacing: 12) {
             Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+                .foregroundStyle(FrostTheme.Colors.success)
             Text("Moved \(viewModel.lastDeletionCount) \(viewModel.lastDeletionCount == 1 ? "file" : "files") to Trash")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white)
@@ -107,7 +107,7 @@ struct ResultsView: View {
     private var skippedFilesBanner: some View {
         HStack(spacing: 8) {
             Image(systemName: AppConstants.Icons.warningTriangle)
-                .foregroundColor(.orange)
+                .foregroundColor(FrostTheme.Colors.warning)
             Text("\(viewModel.lastScanSkippedCount) \(AppConstants.Strings.filesSkippedSuffix)")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(.secondary)
@@ -122,7 +122,7 @@ struct ResultsView: View {
         VStack(spacing: 24) {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 64, weight: .light))
-                .foregroundStyle(.green)
+                .foregroundStyle(FrostTheme.Colors.success)
                 .symbolRenderingMode(.hierarchical)
                 .accessibilityHidden(true)
                 .scaleEffect(reduceMotion ? 1.0 : (isAnimatingCheckmark ? 1.0 : 0.5))
@@ -190,7 +190,7 @@ struct ResultsView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(.ultraThinMaterial)
+                .background(Color.primary.opacity(0.06))
                 .cornerRadius(8)
                 .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.2), lineWidth: 0.5))
 
@@ -274,17 +274,17 @@ struct ResultsView: View {
                 .frame(width: 0, height: 0)
                 .accessibilityHidden(true)
 
-                StatTile(icon: "square.on.square.fill", tint: .blue, value: "\(groups.count)", label: "Duplicate Groups")
+                StatTile(icon: "square.on.square.fill", tint: FrostTheme.Colors.brand, value: "\(groups.count)", label: "Duplicate Groups")
 
                 Divider().frame(height: 24)
 
-                StatTile(icon: "photo.fill.on.rectangle.fill", tint: .purple, value: "\(totalDuplicates)", label: "Total Duplicates")
+                StatTile(icon: "photo.fill.on.rectangle.fill", tint: FrostTheme.Colors.brandAlt, value: "\(totalDuplicates)", label: "Total Duplicates")
 
                 Divider().frame(height: 24)
 
                 StatTile(
                     icon: "arrow.down.circle.fill",
-                    tint: .green,
+                    tint: FrostTheme.Colors.success,
                     value: ByteCountFormatter.string(fromByteCount: potentialSavings, countStyle: .file),
                     label: "Can Be Freed"
                 )
@@ -299,7 +299,7 @@ struct ResultsView: View {
                     HStack(spacing: 6) {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 12))
-                            .foregroundStyle(.blue)
+                            .foregroundStyle(FrostTheme.Colors.brand)
                         Text("\(viewModel.selectedFiles.count) selected")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundColor(.secondary)

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -45,6 +45,20 @@ struct ResultsView: View {
             // Background handled by App container
             
             VStack(spacing: 0) {
+                if viewModel.lastScanSkippedCount > 0 {
+                    HStack(spacing: 8) {
+                        Image(systemName: AppConstants.Icons.warningTriangle)
+                            .foregroundColor(.orange)
+                        Text("\(viewModel.lastScanSkippedCount) \(AppConstants.Strings.filesSkippedSuffix)")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
+                }
+
                 if groups.isEmpty {
                     VStack(spacing: 24) {
                         Image(systemName: "checkmark.circle.fill")
@@ -284,22 +298,3 @@ struct ResultsView: View {
     }
 }
 
-
-
-// Helper function to load AppIcon from correct location
-private func loadAppIcon() -> NSImage? {
-    // Try loading from named asset (works in development with swift run)
-    if let image = NSImage(named: "AppIcon") {
-        return image
-    }
-    
-    // Try loading from resource bundle (works in packaged .app)
-    if let resourceBundle = Bundle.main.url(forResource: "TwinPixCleaner_TwinPixCleaner", withExtension: "bundle"),
-       let bundle = Bundle(url: resourceBundle),
-       let imagePath = bundle.path(forResource: "AppIcon", ofType: "png"),
-       let image = NSImage(contentsOfFile: imagePath) {
-        return image
-    }
-    
-    return nil
-}

--- a/Sources/TwinPixCleaner/UI/ScanningView.swift
+++ b/Sources/TwinPixCleaner/UI/ScanningView.swift
@@ -38,7 +38,7 @@ struct ScanningView: View {
                     .frame(width: 360)
                     .tint(.indigo)
                 
-                Text("\(Int(viewModel.scanProgress * 100))% Complete")
+                Text(String(format: AppConstants.Strings.scanComplete, Int(viewModel.scanProgress * 100)))
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.secondary)
             }

--- a/Sources/TwinPixCleaner/UI/ScanningView.swift
+++ b/Sources/TwinPixCleaner/UI/ScanningView.swift
@@ -38,7 +38,7 @@ struct ScanningView: View {
             VStack(spacing: 12) {
                 ProgressView(value: viewModel.scanProgress, total: 1.0)
                     .frame(width: 360)
-                    .tint(.indigo)
+                    .tint(FrostTheme.Colors.brand)
                     .accessibilityLabel("Scan progress")
                     .accessibilityValue("\(Int(viewModel.scanProgress * 100)) percent")
                 

--- a/Sources/TwinPixCleaner/UI/ScanningView.swift
+++ b/Sources/TwinPixCleaner/UI/ScanningView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct ScanningView: View {
     @ObservedObject var viewModel: AppViewModel
     @State private var isAnimating = false
-    
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         VStack(spacing: 30) {
             // Icon
@@ -11,9 +12,10 @@ struct ScanningView: View {
                 .font(.system(size: 60, weight: .light))
                 .foregroundStyle(FrostTheme.accentGradient)
                 .symbolRenderingMode(.hierarchical)
-                .scaleEffect(isAnimating ? 1.1 : 0.9)
-                .opacity(isAnimating ? 1.0 : 0.5)
-                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: isAnimating)
+                .accessibilityHidden(true)
+                .scaleEffect(reduceMotion ? 1.0 : (isAnimating ? 1.1 : 0.9))
+                .opacity(reduceMotion ? 1.0 : (isAnimating ? 1.0 : 0.5))
+                .animation(reduceMotion ? nil : .easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: isAnimating)
                 .onAppear {
                     isAnimating = true
                 }
@@ -37,6 +39,8 @@ struct ScanningView: View {
                 ProgressView(value: viewModel.scanProgress, total: 1.0)
                     .frame(width: 360)
                     .tint(.indigo)
+                    .accessibilityLabel("Scan progress")
+                    .accessibilityValue("\(Int(viewModel.scanProgress * 100)) percent")
                 
                 Text(String(format: AppConstants.Strings.scanComplete, Int(viewModel.scanProgress * 100)))
                     .font(.system(size: 13, weight: .medium))

--- a/Sources/TwinPixCleaner/UI/Theme.swift
+++ b/Sources/TwinPixCleaner/UI/Theme.swift
@@ -28,14 +28,17 @@ struct ThemeToggle: View {
     @AppStorage("appTheme") private var currentTheme: AppTheme = .system
     
     var body: some View {
-        Picker("", selection: $currentTheme) {
+        Picker("Appearance", selection: $currentTheme) {
             ForEach(AppTheme.allCases) { theme in
                 Image(systemName: theme.icon)
                     .font(.system(size: 16, weight: .medium))
                     .tag(theme)
+                    .accessibilityLabel(theme.rawValue)
             }
         }
         .pickerStyle(.segmented)
         .labelsHidden()
+        .accessibilityLabel("Appearance")
+        .accessibilityValue(currentTheme.rawValue)
     }
 }

--- a/Sources/TwinPixCleaner/UI/UniversalImageView.swift
+++ b/Sources/TwinPixCleaner/UI/UniversalImageView.swift
@@ -63,21 +63,13 @@ struct UniversalImageView: View {
     }
     
     private func loadPhotoAsset() {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let idItem = components.queryItems?.first(where: { $0.name == "id" }),
-              let localIdentifier = idItem.value else {
+        guard let asset = PhotosAssetURL.asset(from: url) else {
             self.hasError = true
             self.isLoading = false
             return
         }
-        
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
-        guard let asset = assets.firstObject else {
-            self.hasError = true
-            self.isLoading = false
-            return
-        }
-        
+
+
         let manager = PHImageManager.default()
         let options = PHImageRequestOptions()
         options.isNetworkAccessAllowed = true

--- a/Sources/TwinPixCleaner/UI/UniversalImageView.swift
+++ b/Sources/TwinPixCleaner/UI/UniversalImageView.swift
@@ -47,17 +47,23 @@ struct UniversalImageView: View {
     }
     
     private func loadFileAsset() {
-        Task {
-            if let nsImage = NSImage(contentsOf: url) {
-                await MainActor.run {
-                    self.image = Image(nsImage: nsImage)
-                    self.isLoading = false
-                }
-            } else {
+        Task.detached(priority: .userInitiated) {
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize: 400,        // matches the Photos path's 400x400 target
+                kCGImageSourceCreateThumbnailWithTransform: true // respect EXIF orientation
+            ]
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+                  let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
                 await MainActor.run {
                     self.hasError = true
                     self.isLoading = false
                 }
+                return
+            }
+            await MainActor.run {
+                self.image = Image(decorative: thumbnail, scale: 1.0)
+                self.isLoading = false
             }
         }
     }

--- a/Tests/TwinPixCleanerTests/SizeHashGroupingTests.swift
+++ b/Tests/TwinPixCleanerTests/SizeHashGroupingTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import TwinPixCleaner
+
+final class SizeHashGroupingTests: XCTestCase {
+
+    private func url(_ name: String) -> URL {
+        URL(fileURLWithPath: "/tmp/\(name)")
+    }
+
+    func testGroupsFilesWithSameSizeAndHash() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let candidates = [(url: a, size: Int64(100), label: "a.jpg"), (url: b, size: Int64(100), label: "b.jpg")]
+
+        let result = await SizeHashGrouping.group(
+            candidates: candidates,
+            hash: { _ in "same-hash" },
+            onProgress: { _, _ in },
+            baseProgress: 0.0,
+            progressSpan: 1.0
+        )
+
+        XCTAssertEqual(result.groups.count, 1)
+        XCTAssertEqual(Set(result.groups[0].fileURLs), Set([a, b]))
+        XCTAssertEqual(result.skippedCount, 0)
+    }
+
+    func testDoesNotGroupSameSizeDifferentHash() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let candidates = [(url: a, size: Int64(100), label: "a.jpg"), (url: b, size: Int64(100), label: "b.jpg")]
+
+        let result = await SizeHashGrouping.group(
+            candidates: candidates,
+            hash: { u in u == a ? "hash-a" : "hash-b" },
+            onProgress: { _, _ in },
+            baseProgress: 0.0,
+            progressSpan: 1.0
+        )
+
+        XCTAssertTrue(result.groups.isEmpty)
+    }
+
+    func testDoesNotGroupAcrossDifferentSizes() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let candidates = [(url: a, size: Int64(100), label: "a.jpg"), (url: b, size: Int64(200), label: "b.jpg")]
+
+        let result = await SizeHashGrouping.group(
+            candidates: candidates,
+            hash: { _ in "same-hash" },
+            onProgress: { _, _ in },
+            baseProgress: 0.0,
+            progressSpan: 1.0
+        )
+
+        XCTAssertTrue(result.groups.isEmpty)
+    }
+
+    func testCountsUnhashableFilesAsSkipped() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let candidates = [(url: a, size: Int64(100), label: "a.jpg"), (url: b, size: Int64(100), label: "b.jpg")]
+
+        let result = await SizeHashGrouping.group(
+            candidates: candidates,
+            hash: { u in u == a ? "hash-a" : nil },
+            onProgress: { _, _ in },
+            baseProgress: 0.0,
+            progressSpan: 1.0
+        )
+
+        XCTAssertTrue(result.groups.isEmpty)
+        XCTAssertEqual(result.skippedCount, 1)
+    }
+}

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -86,12 +86,7 @@ TwinPixCleaner offers two scanning modes:
   - Compression levels
   - Minor edits or crops
   - File formats (JPG vs PNG of same image)
-
-**Similarity Threshold Slider:**
-- **Strict (Left)**: Only finds nearly identical images
-- **Loose (Right)**: Finds images with more visible differences
-- Adjust based on your needs
-- Start with default (middle) and adjust if needed
+- Uses a fixed similarity threshold tuned for reliable results — there's no manual slider to adjust
 
 > **Tip**: Use Exact Match for finding true duplicates to delete. Use Visual Similarity to find similar photos you may want to review manually.
 
@@ -171,7 +166,7 @@ This helps you decide which copy to keep.
 
 **Single Selection:**
 - Click on any image to select it
-- Selected images show a blue border and checkmark
+- Selected images show an accent-colored border and checkmark (matches your macOS accent color)
 - Click again to deselect
 
 **Multiple Selection:**
@@ -205,10 +200,13 @@ This helps you decide which copy to keep.
 - Footer stats **update automatically**
 - Finder files are moved to **Trash** (recoverable)
 - Apple Photos are moved to the **"Recently Deleted"** album
+- A toast appears at the bottom of the screen — **"Moved N files to Trash · Undo"** — with a one-click **Undo** button that restores everything you just deleted, no need to dig through Trash
 
 ### Recovering Deleted Files
 
-If you deleted a file by mistake:
+If you deleted a file by mistake, the fastest fix is the **Undo** button on the toast that appears right after deletion (it stays visible for a few seconds). You can also press **⌘Z** at any time during your session to undo the most recent deletion.
+
+If the toast has already disappeared and you're past the ⌘Z window:
 
 **For Finder Files:**
 1. Open **Finder**
@@ -367,6 +365,15 @@ If you deleted a file by mistake:
 | ⌘Q | Quit app |
 | Click | Select/deselect file |
 | Hover | View file details |
+
+---
+
+## Accessibility
+
+TwinPixCleaner supports:
+- **VoiceOver**: each duplicate thumbnail announces its filename and full metadata (dimensions, date, path), with actions to toggle selection or open Quick Look preview
+- **Full Keyboard Access**: Tab between thumbnails and press Return/Space to select, without needing a mouse
+- **Reduce Motion**: animations (the scanning pulse, the empty-state checkmark) respect this System Settings preference
 
 ---
 


### PR DESCRIPTION
## Summary

This brings `main` up to date with `dev`, covering several rounds of scan/delete reliability fixes and a full UX/accessibility pass on the Results and Dashboard screens:

- Fixes scan/delete reliability bugs, dedupes the scanner pipelines, and hardens error handling
- Extracts reusable UI components and decomposes large view bodies for maintainability
- Fixes the Help menu to open the in-app User Guide instead of an external link
- Adds a delete confirmation flow, then simplifies it to rely solely on an undo toast (with accumulate-correctly-on-repeat-delete behavior) so every delete path behaves identically
- Adds VoiceOver support, Reduce Motion handling, and restores Full Keyboard Access on duplicate thumbnails (including a follow-up fix for a Space-to-preview reliability regression)
- Reflows duplicate thumbnails into an adaptive grid instead of a fixed horizontal-scroll strip
- Derives the accent color gradient from the user's system accent color and consolidates ad-hoc tint colors into semantic tokens, still within the existing frosted-glass design language
- Speeds up thumbnail rendering (downsampled image decode) and caches file metadata lookups
- Updates README.md and USER_GUIDE.md to document the above and correct stale/inaccurate documentation
