### PR TITLE
Merge dev into main: color tokens, Dock icon fix, v2.1.0, community docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Something isn't working the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please check [existing issues](https://github.com/AkshayKrGupta/TwinPixCleaner/issues) first to avoid duplicates.
+
+        If this is a **security vulnerability**, please do not file a public issue — see [SECURITY.md](https://github.com/AkshayKrGupta/TwinPixCleaner/blob/main/SECURITY.md) instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we see this happen ourselves?
+      placeholder: |
+        1. Open TwinPixCleaner
+        2. Scan folder '...'
+        3. Click '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: TwinPixCleaner version
+      description: Found in the app footer, or via TwinPixCleaner → About TwinPixCleaner
+      placeholder: e.g. 2.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: e.g. macOS 15.1 (Sequoia)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install the app?
+      options:
+        - Downloaded release (.app / .dmg)
+        - Built from source
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console logs or screenshots (optional)
+      description: Anything from the macOS Console app or a screenshot that shows the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/AkshayKrGupta/TwinPixCleaner/security/advisories/new
+    about: Please report security vulnerabilities privately instead of filing a public issue — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest an idea, improvement, or new capability
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please check [existing issues](https://github.com/AkshayKrGupta/TwinPixCleaner/issues) first in case it's already been requested.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that TwinPixCleaner doesn't currently support well?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or change you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Any workarounds you're using today, or other approaches you thought about.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be interested in implementing this myself (see CONTRIBUTING.md)
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- Closes #123, or "N/A" -->
+
+## Test plan
+
+<!-- How did you verify this works? For UI changes, built and ran TwinPixCleaner.app (not `swift run` — see README's Photos-permission note). -->
+
+- [ ] `swift build` succeeds
+- [ ] Manually tested the change in the built `.app`
+
+## Checklist
+
+- [ ] This PR targets `dev`, not `main`
+- [ ] Branch is named `feat/...` or `fix/...`
+- [ ] Commit messages follow the `(flag) message` format described in [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,13 @@ fastlane/test_output
 !USER_GUIDE.md
 !PRIVACY.md
 !SECURITY.md
+!CONTRIBUTING.md
+!CODE_OF_CONDUCT.md
+!.github/**/*.md
 
 # Artifacts and Staging
 TwinPixCleaner.dmg
 TwinPixCleaner_dmg/
 Contents/
 *.sh
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,111 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions), and also applies when an individual is officially
+representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, Akshay K Gupta, via
+[LinkedIn](https://www.linkedin.com/in/akshay-kr-gupta/). All complaints will
+be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the
+nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to TwinPixCleaner
+
+Thanks for your interest in contributing! This document covers how to report issues, suggest features, and submit changes.
+
+## Reporting bugs or requesting features
+
+Please use the issue templates:
+- [Report a bug](https://github.com/AkshayKrGupta/TwinPixCleaner/issues/new?template=bug_report.yml)
+- [Request a feature](https://github.com/AkshayKrGupta/TwinPixCleaner/issues/new?template=feature_request.yml)
+
+Search [existing issues](https://github.com/AkshayKrGupta/TwinPixCleaner/issues) first to avoid duplicates. For security vulnerabilities, see [SECURITY.md](SECURITY.md) instead of filing a public issue.
+
+## Development setup
+
+See the [README's "Build from Source"](README.md#option-2-build-from-source) section for build commands and the Apple Photos permission caveat (you need `./scripts/build_app.sh` and the bundled `.app`, not `swift run`, to test Photos-library scanning).
+
+There is no test target in `Package.swift` currently — don't assume `swift test` works.
+
+## Branching strategy
+
+- Never commit directly to `main` or `dev`.
+- Branch off the latest `dev`:
+  ```bash
+  git fetch origin dev
+  git checkout -b feat/your-feature-name origin/dev   # new features
+  git checkout -b fix/your-fix-name origin/dev         # bug fixes
+  ```
+- Open your pull request against `dev`, not `main`. Releases are merged from `dev` into `main` separately.
+
+## Commit messages
+
+Format: `(flag) message`
+
+- Flags: `(fix)`, `(feature)`, `(ui)` — pick whichever matches the change. Use another short lowercase flag (e.g. `(chore)`, `(refactor)`) only if none of those fit.
+- No emoji.
+- Cover, in plain language: what changed, which feature/screen it affects, and what value it delivers. Skip filler like "updated code."
+
+Example:
+```
+(feature) add pagination to results list
+
+Lets users page through large duplicate sets instead of loading
+everything at once, reducing memory use on big scans.
+```
+
+## Pull requests
+
+- Keep PRs focused — one logical change per PR is easier to review than a bundle of unrelated fixes.
+- Fill out the PR template: what changed, how you tested it, and link the issue it addresses if there is one.
+- Build and run the actual `.app` bundle (`./scripts/build_app.sh`) to verify UI/Photos-related changes before opening the PR — `swift build` passing isn't sufficient proof a UI change works.
+
+## Code style
+
+- Follow the existing project structure: `Core/` holds logic with no SwiftUI dependency, `UI/` holds views and the view model.
+- Reuse existing constants and components (`Core/AppConstants.swift` for strings/icons/metrics, `FrostTheme.swift` for colors) instead of inlining new literals.
+- Prefer the smallest change that solves the problem — this project favors straightforward SwiftUI over premature abstraction.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you're expected to uphold it.

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.akshaykgupta.TwinPixCleaner</string>
     <key>CFBundleVersion</key>
-    <string>2</string>
+    <string>3</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.0</string>
+    <string>2.1.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/README.md
+++ b/README.md
@@ -219,11 +219,7 @@ Read our full [Privacy Policy](PRIVACY.md)
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please:
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Submit a pull request
+Contributions are welcome! Found a bug, have a feature idea, or want to submit a change? See [CONTRIBUTING.md](CONTRIBUTING.md) for how to report issues, our branching strategy, and commit message format. This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-13.0+-blue.svg" alt="macOS 13.0+">
   <img src="https://img.shields.io/badge/Swift-6.0-orange.svg" alt="Swift 6.0">
-  <img src="https://img.shields.io/badge/version-2.0.0-green.svg" alt="Version 2.0.0">
+  <img src="https://img.shields.io/badge/version-2.1.0-green.svg" alt="Version 2.1.0">
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache-2.0">
 </p>
 

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -183,7 +183,7 @@ struct DashboardView: View {
                     }) {
                         Text(AppConstants.Strings.developerName)
                             .font(.caption2)
-                            .foregroundColor(.blue)
+                            .foregroundColor(FrostTheme.Colors.brand)
                     }
                     .buttonStyle(.plain)
                 }
@@ -214,7 +214,7 @@ private struct FeatureBullet: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
-                .foregroundColor(.green)
+                .foregroundColor(FrostTheme.Colors.success)
                 .accessibilityHidden(true)
             Text(text)
                 .font(.body)

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -167,7 +167,7 @@ struct DashboardView: View {
             }
 
             VStack(spacing: 4) {
-                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0") • Made with ❤️ for macOS")
+                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.1.0") • Made with ❤️ for macOS")
                     .font(.caption2)
                     .foregroundColor(.secondary)
 

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -30,7 +30,7 @@ struct MenuCommands: Commands {
         CommandGroup(replacing: .appInfo) {
             Button("About TwinPixCleaner") {
                 let info = Bundle.main.infoDictionary
-                let version = info?["CFBundleShortVersionString"] as? String ?? "2.0.0"
+                let version = info?["CFBundleShortVersionString"] as? String ?? "2.1.0"
                 let build = info?["CFBundleVersion"] as? String ?? "1"
                 NSApplication.shared.orderFrontStandardAboutPanel(
                     options: [

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -38,9 +38,31 @@ else
     echo "⚠️ Warning: Info.plist not found, using default"
 fi
 
-# 5. Copy Icon (if exists)
+# 5. Generate AppIcon.icns from AppIcon.png, then copy it into the bundle
+# (AppIcon.png is source-format JPEG despite its extension, so every sips call below
+# forces PNG output — iconutil rejects iconset members that aren't real PNGs.)
+if [ -f "AppIcon.png" ]; then
+    ICONSET="AppIcon.iconset"
+    rm -rf "$ICONSET"
+    mkdir -p "$ICONSET"
+    sips -s format png -z 16 16   AppIcon.png --out "$ICONSET/icon_16x16.png"      > /dev/null
+    sips -s format png -z 32 32   AppIcon.png --out "$ICONSET/icon_16x16@2x.png"   > /dev/null
+    sips -s format png -z 32 32   AppIcon.png --out "$ICONSET/icon_32x32.png"      > /dev/null
+    sips -s format png -z 64 64   AppIcon.png --out "$ICONSET/icon_32x32@2x.png"   > /dev/null
+    sips -s format png -z 128 128 AppIcon.png --out "$ICONSET/icon_128x128.png"    > /dev/null
+    sips -s format png -z 256 256 AppIcon.png --out "$ICONSET/icon_128x128@2x.png" > /dev/null
+    sips -s format png -z 256 256 AppIcon.png --out "$ICONSET/icon_256x256.png"    > /dev/null
+    sips -s format png -z 512 512 AppIcon.png --out "$ICONSET/icon_256x256@2x.png" > /dev/null
+    sips -s format png -z 512 512 AppIcon.png --out "$ICONSET/icon_512x512.png"    > /dev/null
+    sips -s format png -z 1024 1024 AppIcon.png --out "$ICONSET/icon_512x512@2x.png" > /dev/null
+    iconutil -c icns "$ICONSET" -o AppIcon.icns
+    rm -rf "$ICONSET"
+fi
+
 if [ -f "AppIcon.icns" ]; then
     cp "AppIcon.icns" "$RESOURCES_DIR/"
+else
+    echo "⚠️ Warning: AppIcon.icns not found/generated — the app will show a generic icon in the Dock"
 fi
 
 # 6. Copy SwiftPM Resources (if exists)


### PR DESCRIPTION
## Summary

Follow-up to #3, bringing `main` up to date with the rest of `dev`:

- Maps the last two raw SwiftUI colors on the Dashboard (the "Developed by" link and the feature-checklist checkmarks) to the existing design tokens, so every color in the UI now traces back to the same accent-derived token set
- Fixes the built `.app` bundle having no Dock icon — `Info.plist` referenced `CFBundleIconFile=AppIcon` but no `.icns` file ever existed; `build_app.sh` now generates one from `AppIcon.png` at build time (also works around `AppIcon.png` actually being a mislabeled JPEG)
- Bumps the app version to 2.1.0 (`Info.plist`, README badge, and the two runtime fallback version strings)
- Adds community contribution files: GitHub issue templates (bug report / feature request), a pull request template, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md`, plus a `.gitignore` fix so those new docs are actually trackable

## Test plan
- [x] `swift build` succeeds
- [x] `./scripts/build_app.sh` produces a working `.app` bundle with a valid `AppIcon.icns` in `Contents/Resources/`
- [x] Verified `Info.plist` in the built bundle reports version 2.1.0 / build 3
- [x] Manual check: Dock icon renders correctly after launching the built `.app`
