### PR TITLE
Vision Feature Print Upgrades & Smarter Clustering

### DIFF
--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -56,8 +56,24 @@ public enum AppConstants {
 
     /// Scan tuning
     public enum Scan {
-        /// Feature-print distance threshold below which two images are considered visually similar.
-        /// Shared by the filesystem and Apple Photos similarity scanners so both stay in sync.
-        public static let similarityThreshold: Float = 8.0
+        /// Rev2 (macOS 14+): precision-first near-duplicate L2 threshold on normalized 768-D prints.
+        public static let similarityThresholdRev2: Float = 0.28
+        /// Rev1 fallback (macOS 13): legacy 2048-D feature-print scale.
+        public static let similarityThresholdRev1: Float = 8.0
+        /// Max pixel size for ImageIO / PhotoKit decode before Vision feature print.
+        public static let featurePrintMaxPixelSize: Int = 768
+        /// Concurrent Vision print tasks (capped vs active CPU count).
+        public static let maxConcurrentFeaturePrints: Int = 6
+
+        /// Active distance threshold for the Vision revision in use on this OS.
+        /// Shared by filesystem and Apple Photos similarity scanners so both stay in sync.
+        public static func activeThreshold() -> Float {
+            if #available(macOS 14.0, *) {
+                return similarityThresholdRev2
+            }
+            return similarityThresholdRev1
+        }
+
+        public static var similarityThreshold: Float { activeThreshold() }
     }
 }

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -58,8 +58,12 @@ public enum AppConstants {
     public enum Scan {
         /// Rev2 (macOS 14+): precision-first near-duplicate L2 threshold on normalized 768-D prints.
         public static let similarityThresholdRev2: Float = 0.28
+        /// Rev2 screenshots: much stricter — Vision collapses UI chrome / ignores text differences.
+        public static let similarityThresholdRev2Screenshot: Float = 0.12
         /// Rev1 fallback (macOS 13): legacy 2048-D feature-print scale.
         public static let similarityThresholdRev1: Float = 8.0
+        /// Rev1 screenshots: proportionally stricter on the legacy distance scale.
+        public static let similarityThresholdRev1Screenshot: Float = 3.0
         /// Max pixel size for ImageIO / PhotoKit decode before Vision feature print.
         public static let featurePrintMaxPixelSize: Int = 768
         /// Concurrent Vision print tasks (capped vs active CPU count).
@@ -74,6 +78,15 @@ public enum AppConstants {
             return similarityThresholdRev1
         }
 
+        /// Stricter threshold for screenshot-only clustering (same OS revision scale).
+        public static func activeScreenshotThreshold() -> Float {
+            if #available(macOS 14.0, *) {
+                return similarityThresholdRev2Screenshot
+            }
+            return similarityThresholdRev1Screenshot
+        }
+
+        /// Alias for `activeThreshold()` — keeps call sites that historically used a stored constant compiling.
         public static var similarityThreshold: Float { activeThreshold() }
     }
 }

--- a/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
@@ -134,4 +134,40 @@ enum FeaturePrintClustering {
         }
         return buckets.values.filter { $0.count > 1 }
     }
+
+    /// Cluster photos and screenshots in separate pools so screenshot UI-chrome false positives
+    /// don't merge with regular photos, and screenshots use a stricter threshold.
+    static func clusterSeparatingScreenshots(
+        prints: [(url: URL, vector: [Float], isScreenshot: Bool)],
+        photoThreshold: Float,
+        screenshotThreshold: Float,
+        onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
+        baseProgress: Double,
+        progressSpan: Double
+    ) async -> [[URL]] {
+        let photos = prints.filter { !$0.isScreenshot }.map { ($0.url, $0.vector) }
+        let screenshots = prints.filter { $0.isScreenshot }.map { ($0.url, $0.vector) }
+        let photoWeight = Double(max(photos.count, 1))
+        let shotWeight = Double(max(screenshots.count, 1))
+        let totalWeight = photoWeight + shotWeight
+        let photoSpan = progressSpan * (photoWeight / totalWeight)
+        let shotSpan = progressSpan - photoSpan
+
+        var groups = await cluster(
+            prints: photos,
+            threshold: photoThreshold,
+            onProgress: onProgress,
+            baseProgress: baseProgress,
+            progressSpan: photoSpan
+        )
+        let shotGroups = await cluster(
+            prints: screenshots,
+            threshold: screenshotThreshold,
+            onProgress: onProgress,
+            baseProgress: baseProgress + photoSpan,
+            progressSpan: shotSpan
+        )
+        groups.append(contentsOf: shotGroups)
+        return groups
+    }
 }

--- a/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
@@ -121,7 +121,7 @@ enum FeaturePrintClustering {
                 if compared % yieldEvery == 0 {
                     // Progress bar tracks pair work; label stays in photo units (not n² pair counts).
                     let fraction = baseProgress + (Double(compared) / Double(totalPairs)) * progressSpan
-                    await onProgress(fraction, "Clustering \(compared)/\(totalPairs)…")
+                    await onProgress(fraction, "Clustering \(i + 1)/\(n)…")
                     await Task.yield()
                 }
             }

--- a/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Vision
 
 /// Shared "group by size, then hash within each size bucket" pipeline used by both
 /// `DuplicateDetector` (filesystem) and `PhotoLibraryScanner` (Apple Photos) exact-match scans.
@@ -57,55 +56,82 @@ enum SizeHashGrouping {
     }
 }
 
-/// Shared O(n²) feature-print clustering used by both `SimilarityDetector` (filesystem)
-/// and `PhotoLibraryScanner` (Apple Photos) similarity scans: two images cluster together
-/// if their Vision feature-print distance is within `threshold`.
+/// Union-find over Accelerate L2 distances. Transitive near-duplicates (A~B, B~C) form one group.
 enum FeaturePrintClustering {
+
+    struct UnionFind {
+        private var parent: [Int]
+        private var rank: [Int]
+
+        init(count: Int) {
+            parent = Array(0..<count)
+            rank = Array(repeating: 0, count: count)
+        }
+
+        mutating func find(_ x: Int) -> Int {
+            if parent[x] != x {
+                parent[x] = find(parent[x])
+            }
+            return parent[x]
+        }
+
+        mutating func union(_ a: Int, _ b: Int) {
+            let ra = find(a)
+            let rb = find(b)
+            if ra == rb { return }
+            if rank[ra] < rank[rb] {
+                parent[ra] = rb
+            } else if rank[ra] > rank[rb] {
+                parent[rb] = ra
+            } else {
+                parent[rb] = ra
+                rank[ra] += 1
+            }
+        }
+    }
+
     static func cluster(
-        prints: [(url: URL, print: VNFeaturePrintObservation)],
+        prints: [(url: URL, vector: [Float])],
         threshold: Float,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
         baseProgress: Double,
         progressSpan: Double
     ) async -> [[URL]] {
-        var groups: [[URL]] = []
-        var processedIndices = Set<Int>()
+        let n = prints.count
+        guard n > 1 else { return [] }
 
-        for i in 0..<prints.count {
-            guard !Task.isCancelled else { return groups }
-            if processedIndices.contains(i) { continue }
+        var uf = UnionFind(count: n)
+        let totalPairs = n * (n - 1) / 2
+        var compared = 0
+        let yieldEvery = max(1, min(10_000, totalPairs / 50))
 
-            let (url1, print1) = prints[i]
-            var groupURLs = [url1]
-            processedIndices.insert(i)
-
-            for j in (i + 1)..<prints.count {
-                if processedIndices.contains(j) { continue }
-                let (url2, print2) = prints[j]
-
-                var distance: Float = 0
-                do {
-                    try print1.computeDistance(&distance, to: print2)
-                    if distance <= threshold {
-                        groupURLs.append(url2)
-                        processedIndices.insert(j)
-                    }
-                } catch {
+        for i in 0..<n {
+            guard !Task.isCancelled else { break }
+            let vi = prints[i].vector
+            for j in (i + 1)..<n {
+                let vj = prints[j].vector
+                guard vi.count == vj.count, !vi.isEmpty else {
+                    compared += 1
                     continue
                 }
-            }
-
-            if groupURLs.count > 1 {
-                groups.append(groupURLs)
-            }
-
-            if i % 10 == 0 {
-                let fraction = baseProgress + (Double(processedIndices.count) / Double(prints.count)) * progressSpan
-                await onProgress(fraction, "Clustering \(processedIndices.count)/\(prints.count)…")
-                await Task.yield()
+                if FeaturePrintEngine.l2Distance(vi, vj) <= threshold {
+                    uf.union(i, j)
+                }
+                compared += 1
+                if compared % yieldEvery == 0 {
+                    // Progress bar tracks pair work; label stays in photo units (not n² pair counts).
+                    let fraction = baseProgress + (Double(compared) / Double(totalPairs)) * progressSpan
+                    await onProgress(fraction, "Clustering \(compared)/\(totalPairs)…")
+                    await Task.yield()
+                }
             }
         }
 
-        return groups
+        var buckets: [Int: [URL]] = [:]
+        for i in 0..<n {
+            let root = uf.find(i)
+            buckets[root, default: []].append(prints[i].url)
+        }
+        return buckets.values.filter { $0.count > 1 }
     }
 }

--- a/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
+++ b/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Vision
+import ImageIO
+import CoreGraphics
+import Accelerate
+import CryptoKit
+
+/// Shared on-device Vision feature-print pipeline for folder and Photos similarity scans.
+/// ImageIO thumbnail decode → Rev2 (macOS 14+) / Rev1 → disk cache → Accelerate L2.
+enum FeaturePrintEngine {
+
+    struct Entry: Sendable {
+        let url: URL
+        let vector: [Float]
+    }
+
+    // MARK: - Revision / threshold helpers
+
+    static var activeRevision: Int {
+        if #available(macOS 14.0, *) {
+            return Int(VNGenerateImageFeaturePrintRequestRevision2)
+        }
+        return Int(VNGenerateImageFeaturePrintRequestRevision1)
+    }
+
+    // MARK: - Disk cache
+
+    static func cacheDirectory() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let dir = base
+            .appendingPathComponent("TwinPixCleaner", isDirectory: true)
+            .appendingPathComponent("feature-prints", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    static func cacheFileURL(forCacheKey key: String) throws -> URL {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        let name = digest.map { String(format: "%02x", $0) }.joined()
+        return try cacheDirectory().appendingPathComponent(name, isDirectory: false)
+    }
+
+    static func fullCacheKey(contentKey: String) -> String {
+        "\(contentKey)|\(activeRevision)|\(AppConstants.Scan.featurePrintMaxPixelSize)"
+    }
+
+    static func contentKey(forFileURL url: URL) -> String? {
+        guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]) else {
+            return nil
+        }
+        let mtime = values.contentModificationDate?.timeIntervalSince1970 ?? 0
+        let size = values.fileSize ?? 0
+        return "\(url.path)|\(mtime)|\(size)"
+    }
+
+    static func contentKey(photoLocalIdentifier: String, modificationDate: Date?) -> String {
+        let mtime = modificationDate?.timeIntervalSince1970 ?? 0
+        return "\(photoLocalIdentifier)|\(mtime)"
+    }
+
+    static func loadCachedVector(cacheKey: String) -> [Float]? {
+        guard let fileURL = try? cacheFileURL(forCacheKey: cacheKey),
+              let data = try? Data(contentsOf: fileURL),
+              data.count >= MemoryLayout<Float>.size,
+              data.count % MemoryLayout<Float>.size == 0 else {
+            return nil
+        }
+        let count = data.count / MemoryLayout<Float>.size
+        return data.withUnsafeBytes { raw in
+            Array(raw.bindMemory(to: Float.self).prefix(count))
+        }
+    }
+
+    static func storeCachedVector(_ vector: [Float], cacheKey: String) {
+        guard !vector.isEmpty,
+              let fileURL = try? cacheFileURL(forCacheKey: cacheKey) else { return }
+        vector.withUnsafeBufferPointer { buf in
+            let data = Data(buffer: buf)
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    // MARK: - Decode
+
+    static func decodeThumbnail(url: URL, maxPixel: Int = AppConstants.Scan.featurePrintMaxPixelSize) -> CGImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+        return thumbnail
+    }
+
+    // MARK: - Vision
+
+    static func makeFeaturePrintRequest() -> VNGenerateImageFeaturePrintRequest {
+        let request = VNGenerateImageFeaturePrintRequest()
+        if #available(macOS 14.0, *) {
+            request.revision = VNGenerateImageFeaturePrintRequestRevision2
+        } else {
+            request.revision = VNGenerateImageFeaturePrintRequestRevision1
+        }
+        // Do not set usesCPUOnly — allow ANE on Apple Silicon.
+        return request
+    }
+
+    static func computeVector(from cgImage: CGImage) -> [Float]? {
+        let request = makeFeaturePrintRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        do {
+            try handler.perform([request])
+            guard let observation = request.results?.first as? VNFeaturePrintObservation,
+                  observation.elementType == .float,
+                  observation.elementCount > 0 else {
+                return nil
+            }
+            let count = observation.elementCount
+            return observation.data.withUnsafeBytes { raw in
+                Array(raw.bindMemory(to: Float.self).prefix(count))
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    /// Cache-aware vector for a filesystem image URL (ImageIO → Vision).
+    static func vector(forFileURL url: URL) -> [Float]? {
+        autoreleasepool {
+            guard let content = contentKey(forFileURL: url) else { return nil }
+            let key = fullCacheKey(contentKey: content)
+            if let cached = loadCachedVector(cacheKey: key) {
+                return cached
+            }
+            guard let cgImage = decodeThumbnail(url: url),
+                  let vector = computeVector(from: cgImage) else {
+                return nil
+            }
+            storeCachedVector(vector, cacheKey: key)
+            return vector
+        }
+    }
+
+    /// Cache-aware vector from an already-decoded image (Photos path).
+    static func vector(fromCGImage cgImage: CGImage, contentKey: String) -> [Float]? {
+        autoreleasepool {
+            let key = fullCacheKey(contentKey: contentKey)
+            if let cached = loadCachedVector(cacheKey: key) {
+                return cached
+            }
+            guard let vector = computeVector(from: cgImage) else { return nil }
+            storeCachedVector(vector, cacheKey: key)
+            return vector
+        }
+    }
+
+    // MARK: - Concurrent file prints
+
+    static func computeFilePrints(
+        urls: [URL],
+        onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
+        baseProgress: Double,
+        progressSpan: Double
+    ) async -> (prints: [Entry], skipped: Int) {
+        let limit = min(
+            AppConstants.Scan.maxConcurrentFeaturePrints,
+            max(1, ProcessInfo.processInfo.activeProcessorCount)
+        )
+        let total = urls.count
+        if total == 0 { return ([], 0) }
+
+        let counter = ProgressCounter()
+        var results: [Entry?] = Array(repeating: nil, count: total)
+        var skipped = 0
+
+        await withTaskGroup(of: (Int, Entry?).self) { group in
+            var nextIndex = 0
+            var inFlight = 0
+
+            func enqueueAvailable() {
+                while inFlight < limit && nextIndex < total {
+                    let index = nextIndex
+                    let url = urls[index]
+                    nextIndex += 1
+                    inFlight += 1
+                    group.addTask {
+                        let vector = vector(forFileURL: url)
+                        let entry = vector.map { Entry(url: url, vector: $0) }
+                        return (index, entry)
+                    }
+                }
+            }
+
+            enqueueAvailable()
+            for await (index, entry) in group {
+                inFlight -= 1
+                if let entry {
+                    results[index] = entry
+                } else {
+                    skipped += 1
+                }
+
+                let done = counter.increment()
+                if done == total || done % 10 == 0 {
+                    let fraction = baseProgress + (Double(done) / Double(total)) * progressSpan
+                    let label = urls[index].lastPathComponent
+                    await onProgress(fraction, label)
+                }
+
+                enqueueAvailable()
+            }
+        }
+
+        return (results.compactMap { $0 }, skipped)
+    }
+
+    // MARK: - Distance
+
+    /// Euclidean L2 distance between two equal-length float feature prints (Accelerate).
+    static func l2Distance(_ a: [Float], _ b: [Float]) -> Float {
+        precondition(a.count == b.count && !a.isEmpty)
+        var distanceSquared: Float = 0
+        vDSP_distancesq(a, 1, b, 1, &distanceSquared, vDSP_Length(a.count))
+        return sqrtf(distanceSquared)
+    }
+}
+
+// MARK: - Progress helper
+
+private final class ProgressCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
+    }
+}

--- a/Sources/TwinPixCleaner/Core/FileScanner.swift
+++ b/Sources/TwinPixCleaner/Core/FileScanner.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 struct FileScanner {
-    static let imageExtensions: Set<String> = ["jpg", "jpeg", "png", "heic", "tiff", "bmp", "gif", "webp"]
+    /// Still-image extensions eligible for compare. See `StillImageEligibility`.
+    static let imageExtensions: Set<String> = StillImageEligibility.allowedExtensions
 
     static func scan(directory: URL) throws -> [URL] {
         var fileURLs: [URL] = []
@@ -13,12 +14,12 @@ struct FileScanner {
         guard let enumerator = fileManager.enumerator(at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: options) else {
             throw AppError.unreadableDirectory(directory)
         }
-        
+
         for case let fileURL as URL in enumerator {
             do {
                 let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
                 if resourceValues.isRegularFile == true {
-                    if imageExtensions.contains(fileURL.pathExtension.lowercased()) {
+                    if StillImageEligibility.isComparableStillImageFile(fileURL) {
                         fileURLs.append(fileURL)
                     }
                 }
@@ -26,7 +27,7 @@ struct FileScanner {
                 print("Error reading file attributes: \(error)")
             }
         }
-        
+
         return fileURLs
     }
 }

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -103,6 +103,7 @@ struct PhotoLibraryScanner: ImageScanner {
         let localIdentifier: String
         let modificationDate: Date?
         let fileSize: Int64
+        let isScreenshot: Bool
     }
 
     private func scanSimilar(
@@ -134,7 +135,8 @@ struct PhotoLibraryScanner: ImageScanner {
                     url: PhotosAssetURL.build(for: asset.localIdentifier),
                     localIdentifier: asset.localIdentifier,
                     modificationDate: asset.modificationDate,
-                    fileSize: fileSize
+                    fileSize: fileSize,
+                    isScreenshot: StillImageEligibility.isScreenshotPhotoAsset(asset)
                 )
             )
 
@@ -153,7 +155,11 @@ struct PhotoLibraryScanner: ImageScanner {
         )
 
         var sizeByURL: [URL: Int64] = [:]
-        for c in candidates { sizeByURL[c.url] = c.fileSize }
+        var screenshotByURL: [URL: Bool] = [:]
+        for c in candidates {
+            sizeByURL[c.url] = c.fileSize
+            screenshotByURL[c.url] = c.isScreenshot
+        }
 
         let prints = printResult.prints
         skipped += printResult.skipped
@@ -165,9 +171,13 @@ struct PhotoLibraryScanner: ImageScanner {
 
         onProgress(0.5, "Comparing images...")
 
-        let clusters = await FeaturePrintClustering.cluster(
-            prints: prints.map { ($0.url, $0.vector) },
-            threshold: AppConstants.Scan.activeThreshold(),
+        let tagged = prints.map { entry in
+            (entry.url, entry.vector, screenshotByURL[entry.url] ?? false)
+        }
+        let clusters = await FeaturePrintClustering.clusterSeparatingScreenshots(
+            prints: tagged,
+            photoThreshold: AppConstants.Scan.activeThreshold(),
+            screenshotThreshold: AppConstants.Scan.activeScreenshotThreshold(),
             onProgress: onProgress,
             baseProgress: 0.5,
             progressSpan: 0.5

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -55,12 +55,20 @@ struct PhotoLibraryScanner: ImageScanner {
 
             let asset = assets.object(at: i)
             let resources = PHAssetResource.assetResources(for: asset)
+            let photoResource = resources.first(where: { $0.type == .photo })
 
-            if let resource = resources.first(where: { $0.type == .photo }) {
+            guard StillImageEligibility.isComparableStillPhotoAsset(asset, resource: photoResource) else {
+                skipped += 1
+                continue
+            }
+
+            if let resource = photoResource {
                 let size = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
                 if size > 0 {
                     let url = PhotosAssetURL.build(for: asset.localIdentifier)
                     candidates.append((url, size, resource.originalFilename))
+                } else {
+                    skipped += 1
                 }
             } else {
                 skipped += 1
@@ -109,8 +117,15 @@ struct PhotoLibraryScanner: ImageScanner {
             guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
 
             let asset = assets.object(at: i)
+            let photoResource = PHAssetResource.assetResources(for: asset).first(where: { $0.type == .photo })
+
+            guard StillImageEligibility.isComparableStillPhotoAsset(asset, resource: photoResource) else {
+                skipped += 1
+                continue
+            }
+
             var fileSize: Int64 = 0
-            if let resource = PHAssetResource.assetResources(for: asset).first(where: { $0.type == .photo }) {
+            if let resource = photoResource {
                 fileSize = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
             }
 

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -1,11 +1,7 @@
 import Foundation
 import Photos
 import CryptoKit
-import Vision
-
-#if os(macOS)
 import AppKit
-#endif
 
 @MainActor
 struct PhotoLibraryScanner: ImageScanner {
@@ -94,82 +90,69 @@ struct PhotoLibraryScanner: ImageScanner {
 
     // MARK: - Visual Similarity Scanning
 
+    private struct PhotoPrintCandidate: Sendable {
+        let url: URL
+        let localIdentifier: String
+        let modificationDate: Date?
+        let fileSize: Int64
+    }
+
     private func scanSimilar(
         assets: PHFetchResult<PHAsset>,
         totalCount: Int,
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
     ) async -> ScanResult {
-        var prints: [(url: URL, print: VNFeaturePrintObservation)] = []
-        var sizeByURL: [URL: Int64] = [:]
+        var candidates: [PhotoPrintCandidate] = []
         var skipped = 0
-        let imageManager = PHImageManager.default()
-        let requestOptions = PHImageRequestOptions()
-        requestOptions.isSynchronous = false
-        requestOptions.deliveryMode = .fastFormat
-        requestOptions.resizeMode = .fast
-        // FIX: Do not silently download iCloud-only assets
-        requestOptions.isNetworkAccessAllowed = false
-
-        let targetSize = CGSize(width: 256, height: 256)
 
         for i in 0..<totalCount {
             guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
 
             let asset = assets.object(at: i)
-
             var fileSize: Int64 = 0
             if let resource = PHAssetResource.assetResources(for: asset).first(where: { $0.type == .photo }) {
                 fileSize = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
             }
 
-            let fraction = 0.05 + (Double(i) / Double(totalCount) * 0.4)
-            onProgress(fraction, "Analyzing visually: \(i)/\(totalCount)")
+            candidates.append(
+                PhotoPrintCandidate(
+                    url: PhotosAssetURL.build(for: asset.localIdentifier),
+                    localIdentifier: asset.localIdentifier,
+                    modificationDate: asset.modificationDate,
+                    fileSize: fileSize
+                )
+            )
 
-            let cgImage = await withCheckedContinuation { continuation in
-                imageManager.requestImage(
-                    for: asset, targetSize: targetSize, contentMode: .aspectFit, options: requestOptions
-                ) { image, info in
-                    // Skip assets not available locally (iCloud-only)
-                    let isInCloud = (info?[PHImageResultIsInCloudKey] as? Bool) ?? false
-                    if isInCloud {
-                        continuation.resume(returning: nil as CGImage?)
-                        return
-                    }
-                    continuation.resume(returning: image?.cgImage(forProposedRect: nil, context: nil, hints: nil))
-                }
+            if i % 100 == 0 {
+                let fraction = 0.05 + (Double(i) / Double(totalCount) * 0.05)
+                onProgress(fraction, "Preparing: \(i)/\(totalCount)")
+                await Task.yield()
             }
+        }
 
-            if let cgImage = cgImage {
-                let request = VNGenerateImageFeaturePrintRequest()
-                request.revision = VNGenerateImageFeaturePrintRequestRevision1
-                let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        let printResult = await computePhotoPrints(
+            candidates: candidates,
+            onProgress: onProgress,
+            baseProgress: 0.1,
+            progressSpan: 0.4
+        )
 
-                do {
-                    try handler.perform([request])
-                    if let featurePrint = request.results?.first as? VNFeaturePrintObservation {
-                        let url = PhotosAssetURL.build(for: asset.localIdentifier)
-                        prints.append((url: url, print: featurePrint))
-                        sizeByURL[url] = fileSize
-                    } else {
-                        skipped += 1
-                    }
-                } catch {
-                    print("Failed to compute print for \(asset.localIdentifier)")
-                    skipped += 1
-                }
-            } else {
-                skipped += 1
-            }
+        var sizeByURL: [URL: Int64] = [:]
+        for c in candidates { sizeByURL[c.url] = c.fileSize }
 
-            if i % 10 == 0 { await Task.yield() }
+        let prints = printResult.prints
+        skipped += printResult.skipped
+
+        if prints.isEmpty {
+            onProgress(1.0, "Complete")
+            return ScanResult(groups: [], skippedCount: skipped)
         }
 
         onProgress(0.5, "Comparing images...")
 
-        let threshold = AppConstants.Scan.similarityThreshold
         let clusters = await FeaturePrintClustering.cluster(
-            prints: prints,
-            threshold: threshold,
+            prints: prints.map { ($0.url, $0.vector) },
+            threshold: AppConstants.Scan.activeThreshold(),
             onProgress: onProgress,
             baseProgress: 0.5,
             progressSpan: 0.5
@@ -185,6 +168,107 @@ struct PhotoLibraryScanner: ImageScanner {
 
         onProgress(1.0, "Complete")
         return ScanResult(groups: groups, skippedCount: skipped)
+    }
+
+    /// Concurrent PhotoKit decode (768 highQuality, local-only) + FeaturePrintEngine Vision/cache.
+    private func computePhotoPrints(
+        candidates: [PhotoPrintCandidate],
+        onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
+        baseProgress: Double,
+        progressSpan: Double
+    ) async -> (prints: [FeaturePrintEngine.Entry], skipped: Int) {
+        let limit = min(
+            AppConstants.Scan.maxConcurrentFeaturePrints,
+            max(1, ProcessInfo.processInfo.activeProcessorCount)
+        )
+        let total = candidates.count
+        if total == 0 { return ([], 0) }
+
+        let maxPixel = AppConstants.Scan.featurePrintMaxPixelSize
+        let counter = PhotoProgressCounter()
+        var results: [FeaturePrintEngine.Entry?] = Array(repeating: nil, count: total)
+        var skipped = 0
+
+        await withTaskGroup(of: (Int, FeaturePrintEngine.Entry?).self) { group in
+            var nextIndex = 0
+            var inFlight = 0
+
+            func enqueueAvailable() {
+                while inFlight < limit && nextIndex < total {
+                    let index = nextIndex
+                    let candidate = candidates[index]
+                    nextIndex += 1
+                    inFlight += 1
+                    group.addTask {
+                        let entry = Self.featurePrint(for: candidate, maxPixel: maxPixel)
+                        return (index, entry)
+                    }
+                }
+            }
+
+            enqueueAvailable()
+            for await (index, entry) in group {
+                inFlight -= 1
+                if let entry {
+                    results[index] = entry
+                } else {
+                    skipped += 1
+                }
+
+                let done = counter.increment()
+                if done == total || done % 10 == 0 {
+                    let fraction = baseProgress + (Double(done) / Double(total)) * progressSpan
+                    onProgress(fraction, "Analyzing visually: \(done)/\(total)")
+                }
+                enqueueAvailable()
+            }
+        }
+
+        return (results.compactMap { $0 }, skipped)
+    }
+
+    /// Background-safe: re-fetches PHAsset by id, sync PhotoKit request, then engine print/cache.
+    nonisolated private static func featurePrint(
+        for candidate: PhotoPrintCandidate,
+        maxPixel: Int
+    ) -> FeaturePrintEngine.Entry? {
+        let contentKey = FeaturePrintEngine.contentKey(
+            photoLocalIdentifier: candidate.localIdentifier,
+            modificationDate: candidate.modificationDate
+        )
+        let cacheKey = FeaturePrintEngine.fullCacheKey(contentKey: contentKey)
+        if let cached = FeaturePrintEngine.loadCachedVector(cacheKey: cacheKey) {
+            return FeaturePrintEngine.Entry(url: candidate.url, vector: cached)
+        }
+
+        let fetch = PHAsset.fetchAssets(withLocalIdentifiers: [candidate.localIdentifier], options: nil)
+        guard let asset = fetch.firstObject else { return nil }
+
+        let requestOptions = PHImageRequestOptions()
+        requestOptions.isSynchronous = true
+        requestOptions.deliveryMode = .highQualityFormat
+        requestOptions.resizeMode = .fast
+        // Never trigger iCloud downloads during a scan
+        requestOptions.isNetworkAccessAllowed = false
+
+        let target = CGSize(width: maxPixel, height: maxPixel)
+        var cgImage: CGImage?
+        PHImageManager.default().requestImage(
+            for: asset,
+            targetSize: target,
+            contentMode: .aspectFit,
+            options: requestOptions
+        ) { image, info in
+            let isInCloud = (info?[PHImageResultIsInCloudKey] as? Bool) ?? false
+            if isInCloud { return }
+            cgImage = image?.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        }
+
+        guard let cgImage,
+              let vector = FeaturePrintEngine.vector(fromCGImage: cgImage, contentKey: contentKey) else {
+            return nil
+        }
+        return FeaturePrintEngine.Entry(url: candidate.url, vector: vector)
     }
 
     /// Hashes the raw stored bytes of the photo asset file using PHAssetResourceManager.
@@ -242,5 +326,17 @@ struct PhotoLibraryScanner: ImageScanner {
                 }
             )
         }
+    }
+}
+
+private final class PhotoProgressCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
     }
 }

--- a/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
+++ b/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// `SimilarityDetector` implements `ImageScanner` to find visually similar, but not identical, images.
 /// Uses `FeaturePrintEngine` (Vision Rev2/Rev1 + disk cache) and union-find clustering.
+/// Screenshots stay in the scan but use a stricter threshold in a separate cluster pool.
 public struct SimilarityDetector: ImageScanner {
 
     /// Distance threshold determining how "different" images can be to still be considered similar.
@@ -28,15 +29,18 @@ public struct SimilarityDetector: ImageScanner {
                 progressSpan: 0.8
             )
 
-            let prints = printResult.prints.map { ($0.url, $0.vector) }
+            let prints = printResult.prints.map {
+                ($0.url, $0.vector, StillImageEligibility.isScreenshotFile($0.url))
+            }
             let skipped = printResult.skipped
 
             if prints.isEmpty { return ScanResult(groups: [], skippedCount: skipped) }
 
             await onProgress(0.8, "Comparing images…")
-            let clusters = await FeaturePrintClustering.cluster(
+            let clusters = await FeaturePrintClustering.clusterSeparatingScreenshots(
                 prints: prints,
-                threshold: threshold,
+                photoThreshold: threshold,
+                screenshotThreshold: AppConstants.Scan.activeScreenshotThreshold(),
                 onProgress: onProgress,
                 baseProgress: 0.8,
                 progressSpan: 0.2

--- a/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
+++ b/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
@@ -1,38 +1,14 @@
 import Foundation
-import Vision
-import AppKit
 
 /// `SimilarityDetector` implements `ImageScanner` to find visually similar, but not identical, images.
-/// It uses Apple's Vision framework to compute ML feature prints and groups images based on a distance threshold.
+/// Uses `FeaturePrintEngine` (Vision Rev2/Rev1 + disk cache) and union-find clustering.
 public struct SimilarityDetector: ImageScanner {
 
     /// Distance threshold determining how "different" images can be to still be considered similar.
-    /// A typical value is 8.0 to 15.0 for moderate similarity.
     public let threshold: Float
 
-    public init(threshold: Float = AppConstants.Scan.similarityThreshold) {
+    public init(threshold: Float = AppConstants.Scan.activeThreshold()) {
         self.threshold = threshold
-    }
-
-    nonisolated private func computeFeaturePrint(for url: URL) -> VNFeaturePrintObservation? {
-        autoreleasepool {
-            guard let image = NSImage(contentsOf: url),
-                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-                return nil
-            }
-
-            let request = VNGenerateImageFeaturePrintRequest()
-            request.revision = VNGenerateImageFeaturePrintRequestRevision1
-
-            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-            do {
-                try handler.perform([request])
-                return request.results?.first as? VNFeaturePrintObservation
-            } catch {
-                print("Failed to compute feature print for \(url.lastPathComponent): \(error)")
-                return nil
-            }
-        }
     }
 
     public func scan(
@@ -44,43 +20,19 @@ public struct SimilarityDetector: ImageScanner {
             let files = try FileScanner.scan(directory: directory)
             if files.isEmpty { return ScanResult(groups: [], skippedCount: 0) }
 
-            // Limit to prevent crashes with large libraries
-            let maxFiles = 500
-            let filesToProcess = files.count > maxFiles ? Array(files.prefix(maxFiles)) : files
+            // No silent cap — concurrency + ImageIO thumbnails bound memory.
+            let printResult = await FeaturePrintEngine.computeFilePrints(
+                urls: files,
+                onProgress: onProgress,
+                baseProgress: 0.0,
+                progressSpan: 0.8
+            )
 
-            var prints: [(url: URL, print: VNFeaturePrintObservation)] = []
-            var skipped = 0
-
-            // 1. Compute feature prints in batches (~0–80% of progress)
-            let batchSize = 50
-            var processedCount = 0
-
-            for batchStart in stride(from: 0, to: filesToProcess.count, by: batchSize) {
-                guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
-                let batchEnd = min(batchStart + batchSize, filesToProcess.count)
-                let batch = Array(filesToProcess[batchStart..<batchEnd])
-
-                for file in batch {
-                    processedCount += 1
-                    let fraction = Double(processedCount) / Double(filesToProcess.count) * 0.8
-                    await onProgress(fraction, file.lastPathComponent)
-
-                    autoreleasepool {
-                        if let print = computeFeaturePrint(for: file) {
-                            prints.append((file, print))
-                        } else {
-                            skipped += 1
-                        }
-                    }
-                }
-
-                // Yield to prevent blocking
-                await Task.yield()
-            }
+            let prints = printResult.prints.map { ($0.url, $0.vector) }
+            let skipped = printResult.skipped
 
             if prints.isEmpty { return ScanResult(groups: [], skippedCount: skipped) }
 
-            // 2. Cluster images (~80–100% of progress)
             await onProgress(0.8, "Comparing images…")
             let clusters = await FeaturePrintClustering.cluster(
                 prints: prints,

--- a/Sources/TwinPixCleaner/Core/StillImageEligibility.swift
+++ b/Sources/TwinPixCleaner/Core/StillImageEligibility.swift
@@ -1,0 +1,71 @@
+import Foundation
+import ImageIO
+import Photos
+import UniformTypeIdentifiers
+
+/// Shared rules for which assets may enter exact/similarity compare pipelines.
+/// Still photos only — no GIF/video/animated multi-frame.
+enum StillImageEligibility {
+
+    /// Extensions allowed for folder scans (still images).
+    static let allowedExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "heic", "heif", "tiff", "tif", "bmp", "webp"
+    ]
+
+    private static let animatedFilenameExtensions: Set<String> = ["gif"]
+
+    // MARK: - Folder / file URLs
+
+    static func isComparableStillImageFile(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        guard allowedExtensions.contains(ext) else { return false }
+        // Animated WebP — skip multi-frame containers.
+        if ext == "webp", imageSourceFrameCount(url) > 1 {
+            return false
+        }
+        return true
+    }
+
+    /// Filename heuristic for folder scans (Photos uses `mediaSubtypes` instead).
+    static func isScreenshotFile(_ url: URL) -> Bool {
+        let name = url.deletingPathExtension().lastPathComponent.lowercased()
+        if name.hasPrefix("screenshot") { return true }
+        if name.hasPrefix("screen shot") { return true }
+        if name.contains("screenshot") { return true }
+        return false
+    }
+
+    // MARK: - Photos library
+
+    static func isComparableStillPhotoAsset(_ asset: PHAsset, resource: PHAssetResource?) -> Bool {
+        if asset.playbackStyle == .imageAnimated || asset.playbackStyle == .video {
+            return false
+        }
+        guard let resource else { return true }
+
+        let filename = resource.originalFilename.lowercased()
+        let ext = (filename as NSString).pathExtension
+        if animatedFilenameExtensions.contains(ext) { return false }
+
+        let uti = resource.uniformTypeIdentifier
+        let utiLower = uti.lowercased()
+        if utiLower.contains("gif") || utiLower.contains("image.animated") {
+            return false
+        }
+        if let type = UTType(uti), type.conforms(to: .audiovisualContent) {
+            return false
+        }
+        return true
+    }
+
+    static func isScreenshotPhotoAsset(_ asset: PHAsset) -> Bool {
+        asset.mediaSubtypes.contains(.photoScreenshot)
+    }
+
+    // MARK: - Helpers
+
+    private static func imageSourceFrameCount(_ url: URL) -> Int {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return 1 }
+        return CGImageSourceGetCount(source)
+    }
+}

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -5,14 +5,20 @@ struct DashboardView: View {
     @State private var isTargeted = false
 
     var body: some View {
-        VStack(spacing: 16) {
-            logoSection
-            aboutSection
-            actionCard
-            Spacer()
-            footerSection
+        GeometryReader { geo in
+            ScrollView {
+                VStack(spacing: 16) {
+                    logoSection
+                    aboutSection
+                    actionCard
+                    Spacer(minLength: 16)
+                    footerSection
+                }
+                .padding()
+                // Fill viewport when tall (footer pinned to bottom); scroll when short.
+                .frame(maxWidth: .infinity, minHeight: geo.size.height)
+            }
         }
-        .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
         .onDrop(of: [.fileURL], isTargeted: $isTargeted) { providers in

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -16,6 +16,7 @@ struct DuplicateItemView: View {
             thumbnail
             infoSection
         }
+        .frame(width: 200)
         .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
         .background(.ultraThinMaterial)
         .cornerRadius(AppConstants.UI.defaultCornerRadius)
@@ -51,14 +52,18 @@ struct DuplicateItemView: View {
         }) {
             ZStack(alignment: .topTrailing) {
                 UniversalImageView(url: url)
+                selectionCheckbox
+            }
+            .frame(width: 200, height: 200)
+            .clipped()
+            .overlay {
+                if isHovering {
+                    ZStack(alignment: .topLeading) {
+                        quickLookHint
+                        metadataOverlay
+                    }
                     .frame(width: 200, height: 200)
                     .clipped()
-
-                selectionCheckbox
-
-                if isHovering {
-                    quickLookHint
-                    metadataOverlay
                 }
             }
             .onHover { hovering in

--- a/Tests/TwinPixCleanerTests/FeaturePrintClusteringTests.swift
+++ b/Tests/TwinPixCleanerTests/FeaturePrintClusteringTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import TwinPixCleaner
+
+final class FeaturePrintClusteringTests: XCTestCase {
+
+    private func url(_ name: String) -> URL {
+        URL(fileURLWithPath: "/tmp/\(name)")
+    }
+
+    /// Three points on a line: A—B—C with A≁C by direct distance, but union-find merges all.
+    func testUnionFindMergesTransitiveChain() async {
+        // 1-D embeddings: A=0, B=1, C=2; threshold 1.5 → A~B, B~C, A!~C
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let c = url("c.jpg")
+        let prints: [(url: URL, vector: [Float])] = [
+            (a, [0]),
+            (b, [1]),
+            (c, [2])
+        ]
+
+        let groups = await FeaturePrintClustering.cluster(
+            prints: prints,
+            threshold: 1.5,
+            onProgress: { _, _ in },
+            baseProgress: 0,
+            progressSpan: 1
+        )
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(Set(groups[0]), Set([a, b, c]))
+    }
+
+    func testDoesNotMergeFarApartPoints() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let prints: [(url: URL, vector: [Float])] = [
+            (a, [0]),
+            (b, [10])
+        ]
+
+        let groups = await FeaturePrintClustering.cluster(
+            prints: prints,
+            threshold: 1.5,
+            onProgress: { _, _ in },
+            baseProgress: 0,
+            progressSpan: 1
+        )
+
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    func testTwoSeparatePairs() async {
+        let a = url("a.jpg")
+        let b = url("b.jpg")
+        let c = url("c.jpg")
+        let d = url("d.jpg")
+        let prints: [(url: URL, vector: [Float])] = [
+            (a, [0]),
+            (b, [0.5]),
+            (c, [100]),
+            (d, [100.5])
+        ]
+
+        let groups = await FeaturePrintClustering.cluster(
+            prints: prints,
+            threshold: 1.0,
+            onProgress: { _, _ in },
+            baseProgress: 0,
+            progressSpan: 1
+        )
+
+        XCTAssertEqual(groups.count, 2)
+        let sets = Set(groups.map { Set($0) })
+        XCTAssertEqual(sets, Set([Set([a, b]), Set([c, d])]))
+    }
+
+    func testL2DistanceIdenticalVectorsIsZero() {
+        let v: [Float] = [0.1, -0.2, 0.3, 0.4]
+        let distance = FeaturePrintEngine.l2Distance(v, v)
+        XCTAssertEqual(distance, 0, accuracy: 1e-6)
+    }
+
+    func testL2DistanceKnownValues() {
+        let a: [Float] = [0, 0, 0]
+        let b: [Float] = [3, 4, 0]
+        let distance = FeaturePrintEngine.l2Distance(a, b)
+        XCTAssertEqual(distance, 5, accuracy: 1e-5)
+    }
+
+    func testRev2ThresholdInExpectedRange() {
+        XCTAssertLessThan(AppConstants.Scan.similarityThresholdRev2, 2.0)
+        XCTAssertGreaterThan(AppConstants.Scan.similarityThresholdRev2, 0)
+        XCTAssertEqual(AppConstants.Scan.similarityThresholdRev1, 8.0)
+        XCTAssertEqual(AppConstants.Scan.featurePrintMaxPixelSize, 768)
+    }
+
+    func testActiveThresholdMatchesRevisionScale() {
+        let threshold = AppConstants.Scan.activeThreshold()
+        let shot = AppConstants.Scan.activeScreenshotThreshold()
+        if #available(macOS 14.0, *) {
+            XCTAssertEqual(threshold, AppConstants.Scan.similarityThresholdRev2)
+            XCTAssertEqual(shot, AppConstants.Scan.similarityThresholdRev2Screenshot)
+            XCTAssertLessThan(shot, threshold)
+        } else {
+            XCTAssertEqual(threshold, AppConstants.Scan.similarityThresholdRev1)
+            XCTAssertEqual(shot, AppConstants.Scan.similarityThresholdRev1Screenshot)
+            XCTAssertLessThan(shot, threshold)
+        }
+    }
+
+    func testScreenshotPoolUsesSeparateThreshold() async {
+        let a = url("Screenshot-a.png")
+        let b = url("Screenshot-b.png")
+        let c = url("photo.jpg")
+        let d = url("photo2.jpg")
+        // Screenshots are moderately close (would merge at 0.28, not at 0.12)
+        let prints: [(url: URL, vector: [Float], isScreenshot: Bool)] = [
+            (a, [0.0], true),
+            (b, [0.20], true),
+            (c, [0.0], false),
+            (d, [0.20], false)
+        ]
+
+        let groups = await FeaturePrintClustering.clusterSeparatingScreenshots(
+            prints: prints,
+            photoThreshold: 0.28,
+            screenshotThreshold: 0.12,
+            onProgress: { _, _ in },
+            baseProgress: 0,
+            progressSpan: 1
+        )
+
+        // Photos merge (0.20 <= 0.28); screenshots stay apart (0.20 > 0.12)
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(Set(groups[0]), Set([c, d]))
+    }
+}

--- a/Tests/TwinPixCleanerTests/StillImageEligibilityTests.swift
+++ b/Tests/TwinPixCleanerTests/StillImageEligibilityTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import TwinPixCleaner
+
+final class StillImageEligibilityTests: XCTestCase {
+
+    func testAllowsCommonStillExtensions() {
+        XCTAssertTrue(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/photo.jpg")))
+        XCTAssertTrue(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/photo.JPEG")))
+        XCTAssertTrue(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/photo.png")))
+        XCTAssertTrue(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/photo.heic")))
+    }
+
+    func testRejectsGifByExtension() {
+        XCTAssertFalse(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/anim.gif")))
+        XCTAssertFalse(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/clip.mp4")))
+        XCTAssertFalse(StillImageEligibility.isComparableStillImageFile(URL(fileURLWithPath: "/a/movie.mov")))
+    }
+
+    func testScreenshotFilenameDetection() {
+        XCTAssertTrue(StillImageEligibility.isScreenshotFile(
+            URL(fileURLWithPath: "/a/Screenshot 2024-01-01 at 12.00.00.png")
+        ))
+        XCTAssertTrue(StillImageEligibility.isScreenshotFile(
+            URL(fileURLWithPath: "/a/Screen Shot 2024-01-01.png")
+        ))
+        XCTAssertFalse(StillImageEligibility.isScreenshotFile(
+            URL(fileURLWithPath: "/a/IMG_1234.HEIC")
+        ))
+    }
+
+    func testGifNotInAllowedExtensions() {
+        XCTAssertFalse(StillImageEligibility.allowedExtensions.contains("gif"))
+        XCTAssertTrue(FileScanner.imageExtensions.isDisjoint(with: ["gif", "mp4", "mov"]))
+    }
+}


### PR DESCRIPTION
## Change Summary

- **Vision Rev2 & Accelerate L2:** Upgraded to Apple Vision Rev2 feature prints on macOS 14+ with vector-accelerated Euclidean distance calculations.
- **Transitive Union-Find Clustering:** Groups multi-photo similar bursts transitively ($A \approx B \approx C$).
- **Still-Photo Eligibility:** Automatically filters out GIFs, videos, and unsupported animations from still-image comparisons.
- **Persistent ML Cache & Pruning:** Feature prints are safely cached on disk to make re-scans instant. Includes automatic startup pruning and a new "Clear Similarity Cache" menu command.
- **Interactive Skipped Items Pane:** Replaced the generic warning banner with an interactive [View Details] sheet. This is related to issue #7 
