### PR TITLE
Dev

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.akshaykgupta.TwinPixCleaner</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.1.0</string>
+    <string>2.2.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-13.0+-blue.svg" alt="macOS 13.0+">
   <img src="https://img.shields.io/badge/Swift-6.0-orange.svg" alt="Swift 6.0">
-  <img src="https://img.shields.io/badge/version-2.1.0-green.svg" alt="Version 2.1.0">
+  <img src="https://img.shields.io/badge/version-2.2.0-green.svg" alt="Version 2.2.0">
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache-2.0">
 </p>
 

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -1,5 +1,13 @@
 import Foundation
 import CoreGraphics
+import os
+
+/// Structured loggers for unified, subsystem-categorized Console.app logging.
+public enum AppLogger {
+    public static let scanner = Logger(subsystem: "com.akshaykrgupta.TwinPixCleaner", category: "Scanner")
+    public static let quickLook = Logger(subsystem: "com.akshaykrgupta.TwinPixCleaner", category: "QuickLook")
+    public static let general = Logger(subsystem: "com.akshaykrgupta.TwinPixCleaner", category: "General")
+}
 
 /// Centralized constants for the entire TwinPixCleaner application.
 /// Using this enum prevents hardcoded magic strings and allows for easy updates/localization.

--- a/Sources/TwinPixCleaner/Core/AppConstants.swift
+++ b/Sources/TwinPixCleaner/Core/AppConstants.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SwiftUI
+import CoreGraphics
 
 /// Centralized constants for the entire TwinPixCleaner application.
 /// Using this enum prevents hardcoded magic strings and allows for easy updates/localization.
@@ -85,8 +85,5 @@ public enum AppConstants {
             }
             return similarityThresholdRev1Screenshot
         }
-
-        /// Alias for `activeThreshold()` — keeps call sites that historically used a stored constant compiling.
-        public static var similarityThreshold: Float { activeThreshold() }
     }
 }

--- a/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
@@ -25,13 +25,13 @@ public struct DuplicateDetector: ImageScanner {
 
             // 2. Build candidates by size (fast pass — ~10% of progress)
             var candidates: [(url: URL, size: Int64, label: String)] = []
-            var skipped = 0
+            var skippedSummary = SkippedSummary()
             for (index, file) in files.enumerated() {
-                guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+                guard !Task.isCancelled else { return ScanResult(groups: [], skippedSummary: skippedSummary) }
                 if let size = ImageHasher.getFileSize(for: file) {
                     candidates.append((file, size, file.lastPathComponent))
                 } else {
-                    skipped += 1
+                    skippedSummary.add(name: file.lastPathComponent, detail: file.path, reason: .unreadableFile)
                 }
                 if index % 50 == 0 {
                     let fraction = Double(index) / Double(files.count) * 0.1
@@ -48,8 +48,10 @@ public struct DuplicateDetector: ImageScanner {
                 progressSpan: 0.9
             )
 
+            skippedSummary.merge(result.skippedSummary)
+
             await onProgress(1.0, "Complete")
-            return ScanResult(groups: result.groups, skippedCount: skipped + result.skippedCount)
+            return ScanResult(groups: result.groups, skippedSummary: skippedSummary)
         }.value
     }
 }

--- a/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateDetector.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CryptoKit
 
 /// `DuplicateDetector` implements `ImageScanner` to find bit-for-bit identical files.
 /// Process:

--- a/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
+++ b/Sources/TwinPixCleaner/Core/DuplicateGrouping.swift
@@ -11,7 +11,7 @@ enum SizeHashGrouping {
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
         baseProgress: Double,
         progressSpan: Double
-    ) async -> (groups: [DuplicateGroup], skippedCount: Int) {
+    ) async -> (groups: [DuplicateGroup], skippedSummary: SkippedSummary, skippedCount: Int) {
         var bySize: [Int64: [(url: URL, label: String)]] = [:]
         for candidate in candidates where candidate.size > 0 {
             bySize[candidate.size, default: []].append((candidate.url, candidate.label))
@@ -20,20 +20,21 @@ enum SizeHashGrouping {
         let potentialDuplicates = bySize.filter { $0.value.count > 1 }
         if potentialDuplicates.isEmpty {
             await onProgress(baseProgress + progressSpan, "Complete")
-            return ([], 0)
+            return ([], SkippedSummary(), 0)
         }
 
         var groups: [DuplicateGroup] = []
+        var skippedSummary = SkippedSummary()
         var skipped = 0
         let totalToHash = potentialDuplicates.values.reduce(0) { $0 + $1.count }
         var hashedCount = 0
 
         for (size, items) in potentialDuplicates {
-            guard !Task.isCancelled else { return (groups, skipped) }
+            guard !Task.isCancelled else { return (groups, skippedSummary, skipped) }
             var byHash: [String: [URL]] = [:]
 
             for item in items {
-                guard !Task.isCancelled else { return (groups, skipped) }
+                guard !Task.isCancelled else { return (groups, skippedSummary, skipped) }
                 hashedCount += 1
                 let fraction = baseProgress + (Double(hashedCount) / Double(totalToHash)) * progressSpan
                 await onProgress(fraction, item.label)
@@ -42,6 +43,7 @@ enum SizeHashGrouping {
                     byHash[h, default: []].append(item.url)
                 } else {
                     skipped += 1
+                    skippedSummary.add(name: item.label, detail: item.url.path, reason: .unreadableFile)
                 }
 
                 if hashedCount % 10 == 0 { await Task.yield() }
@@ -52,7 +54,7 @@ enum SizeHashGrouping {
             }
         }
 
-        return (groups, skipped)
+        return (groups, skippedSummary, skipped)
     }
 }
 

--- a/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
+++ b/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
@@ -201,16 +201,17 @@ enum FeaturePrintEngine {
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
         baseProgress: Double,
         progressSpan: Double
-    ) async -> (prints: [Entry], skipped: Int) {
+    ) async -> (prints: [Entry], skippedSummary: SkippedSummary, skipped: Int) {
         let limit = min(
             AppConstants.Scan.maxConcurrentFeaturePrints,
             max(1, ProcessInfo.processInfo.activeProcessorCount)
         )
         let total = urls.count
-        if total == 0 { return ([], 0) }
+        if total == 0 { return ([], SkippedSummary(), 0) }
 
         let counter = ProgressCounter()
         var results: [Entry?] = Array(repeating: nil, count: total)
+        var skippedSummary = SkippedSummary()
         var skipped = 0
 
         await withTaskGroup(of: (Int, Entry?).self) { group in
@@ -238,6 +239,7 @@ enum FeaturePrintEngine {
                     results[index] = entry
                 } else {
                     skipped += 1
+                    skippedSummary.add(name: urls[index].lastPathComponent, detail: urls[index].path, reason: .unreadableFile)
                 }
 
                 let done = counter.increment()
@@ -251,7 +253,7 @@ enum FeaturePrintEngine {
             }
         }
 
-        return (results.compactMap { $0 }, skipped)
+        return (results.compactMap { $0 }, skippedSummary, skipped)
     }
 
     // MARK: - Distance

--- a/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
+++ b/Sources/TwinPixCleaner/Core/FeaturePrintEngine.swift
@@ -85,6 +85,38 @@ enum FeaturePrintEngine {
         }
     }
 
+    /// Completely removes all cached feature prints from disk.
+    @discardableResult
+    static func clearCache() -> Bool {
+        guard let dir = try? cacheDirectory() else { return false }
+        do {
+            try FileManager.default.removeItem(at: dir)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Prunes cached feature print files older than `maxAgeDays` (default 30 days).
+    static func pruneCache(maxAgeDays: Int = 30) {
+        guard let dir = try? cacheDirectory() else { return }
+        let cutoff = Date().addingTimeInterval(-Double(maxAgeDays * 24 * 3600))
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: .skipsHiddenFiles
+        ) else { return }
+
+        for file in files {
+            if let values = try? file.resourceValues(forKeys: [.contentModificationDateKey]),
+               let mdate = values.contentModificationDate,
+               mdate < cutoff {
+                try? FileManager.default.removeItem(at: file)
+            }
+        }
+    }
+
     // MARK: - Decode
 
     static func decodeThumbnail(url: URL, maxPixel: Int = AppConstants.Scan.featurePrintMaxPixelSize) -> CGImage? {

--- a/Sources/TwinPixCleaner/Core/FileDeleter.swift
+++ b/Sources/TwinPixCleaner/Core/FileDeleter.swift
@@ -76,10 +76,21 @@ struct FileDeleter {
         for url in fileURLs {
             do {
                 var resultingURL: NSURL?
-                try FileManager.default.trashItem(at: url, resultingItemURL: &resultingURL)
-                results[url] = (resultingURL as URL?) ?? url
+                let targetURL = url.standardizedFileURL
+                try FileManager.default.trashItem(at: targetURL, resultingItemURL: &resultingURL)
+                results[url] = (resultingURL as URL?) ?? targetURL
             } catch {
-                continue
+                AppLogger.general.error("Failed to trash item at \(url.path): \(error.localizedDescription)")
+                // Retry with raw URL if standardized differs
+                if url != url.standardizedFileURL {
+                    do {
+                        var resultingURL: NSURL?
+                        try FileManager.default.trashItem(at: url, resultingItemURL: &resultingURL)
+                        results[url] = (resultingURL as URL?) ?? url
+                    } catch {
+                        continue
+                    }
+                }
             }
         }
 

--- a/Sources/TwinPixCleaner/Core/FileScanner.swift
+++ b/Sources/TwinPixCleaner/Core/FileScanner.swift
@@ -24,7 +24,7 @@ struct FileScanner {
                     }
                 }
             } catch {
-                print("Error reading file attributes: \(error)")
+                AppLogger.scanner.error("Error reading file attributes for \(fileURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
 

--- a/Sources/TwinPixCleaner/Core/ImageHasher.swift
+++ b/Sources/TwinPixCleaner/Core/ImageHasher.swift
@@ -4,7 +4,7 @@ import CryptoKit
 struct ImageHasher {
     static func computeHash(for url: URL) -> String? {
         guard let handle = FileHandle(forReadingAtPath: url.path) else {
-            print("Error hashing file \(url.lastPathComponent): could not open for reading")
+            AppLogger.scanner.error("Error hashing file \(url.lastPathComponent, privacy: .public): could not open for reading")
             return nil
         }
         defer { try? handle.close() }
@@ -16,7 +16,7 @@ struct ImageHasher {
                 hasher.update(data: chunk)
             }
         } catch {
-            print("Error hashing file \(url.lastPathComponent): \(error)")
+            AppLogger.scanner.error("Error hashing file \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return nil
         }
 
@@ -29,7 +29,7 @@ struct ImageHasher {
             let resources = try url.resourceValues(forKeys: [.fileSizeKey])
             return Int64(resources.fileSize ?? 0)
         } catch {
-            print("Error getting file size for \(url.lastPathComponent): \(error)")
+            AppLogger.scanner.error("Error getting file size for \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/Sources/TwinPixCleaner/Core/ImageScanner.swift
+++ b/Sources/TwinPixCleaner/Core/ImageScanner.swift
@@ -17,15 +17,27 @@ public struct DuplicateGroup: Identifiable, Hashable, Sendable {
     }
 }
 
-/// The outcome of a scan: the duplicate groups found, plus how many files were skipped
-/// because they couldn't be read/hashed/analyzed.
+/// The outcome of a scan: the duplicate groups found, plus a summary of any skipped files.
 public struct ScanResult: Sendable {
     public let groups: [DuplicateGroup]
-    public let skippedCount: Int
+    public let skippedSummary: SkippedSummary
+
+    public var skippedCount: Int { skippedSummary.totalCount }
+
+    public init(groups: [DuplicateGroup], skippedSummary: SkippedSummary) {
+        self.groups = groups
+        self.skippedSummary = skippedSummary
+    }
 
     public init(groups: [DuplicateGroup], skippedCount: Int) {
         self.groups = groups
-        self.skippedCount = skippedCount
+        var summary = SkippedSummary()
+        if skippedCount > 0 {
+            for _ in 0..<skippedCount {
+                summary.add(name: "Skipped item", reason: .unreadableFile)
+            }
+        }
+        self.skippedSummary = summary
     }
 }
 

--- a/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
+++ b/Sources/TwinPixCleaner/Core/PhotoLibraryScanner.swift
@@ -47,18 +47,22 @@ struct PhotoLibraryScanner: ImageScanner {
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
     ) async -> ScanResult {
         var candidates: [(url: URL, size: Int64, label: String)] = []
-        var skipped = 0
+        var skippedSummary = SkippedSummary()
 
         // 1. Build candidates by file size — skip iCloud-only assets that have no local resource
         for i in 0..<totalCount {
-            guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+            guard !Task.isCancelled else { return ScanResult(groups: [], skippedSummary: skippedSummary) }
 
             let asset = assets.object(at: i)
             let resources = PHAssetResource.assetResources(for: asset)
             let photoResource = resources.first(where: { $0.type == .photo })
 
             guard StillImageEligibility.isComparableStillPhotoAsset(asset, resource: photoResource) else {
-                skipped += 1
+                skippedSummary.add(
+                    name: photoResource?.originalFilename ?? "Asset \(i + 1)",
+                    detail: PhotosAssetURL.build(for: asset.localIdentifier).absoluteString,
+                    reason: .unsupportedFormat
+                )
                 continue
             }
 
@@ -68,10 +72,18 @@ struct PhotoLibraryScanner: ImageScanner {
                     let url = PhotosAssetURL.build(for: asset.localIdentifier)
                     candidates.append((url, size, resource.originalFilename))
                 } else {
-                    skipped += 1
+                    skippedSummary.add(
+                        name: resource.originalFilename,
+                        detail: PhotosAssetURL.build(for: asset.localIdentifier).absoluteString,
+                        reason: .inCloudOnly
+                    )
                 }
             } else {
-                skipped += 1
+                skippedSummary.add(
+                    name: "Asset \(i + 1)",
+                    detail: PhotosAssetURL.build(for: asset.localIdentifier).absoluteString,
+                    reason: .inCloudOnly
+                )
             }
 
             if i % 100 == 0 {
@@ -82,8 +94,6 @@ struct PhotoLibraryScanner: ImageScanner {
         }
 
         // 2. Group by size, then hash the raw stored bytes within each size bucket.
-        // PHAsset isn't Sendable, so the hash closure re-resolves the asset from the
-        // (Sendable) photos:// URL instead of capturing PHAsset objects across the boundary.
         let result = await SizeHashGrouping.group(
             candidates: candidates,
             hash: { url in await self.computeHash(forPhotoURL: url) },
@@ -92,8 +102,10 @@ struct PhotoLibraryScanner: ImageScanner {
             progressSpan: 0.85
         )
 
+        skippedSummary.merge(result.skippedSummary)
+
         onProgress(1.0, "Complete")
-        return ScanResult(groups: result.groups, skippedCount: skipped + result.skippedCount)
+        return ScanResult(groups: result.groups, skippedSummary: skippedSummary)
     }
 
     // MARK: - Visual Similarity Scanning
@@ -101,6 +113,7 @@ struct PhotoLibraryScanner: ImageScanner {
     private struct PhotoPrintCandidate: Sendable {
         let url: URL
         let localIdentifier: String
+        let filename: String
         let modificationDate: Date?
         let fileSize: Int64
         let isScreenshot: Bool
@@ -112,16 +125,20 @@ struct PhotoLibraryScanner: ImageScanner {
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void
     ) async -> ScanResult {
         var candidates: [PhotoPrintCandidate] = []
-        var skipped = 0
+        var skippedSummary = SkippedSummary()
 
         for i in 0..<totalCount {
-            guard !Task.isCancelled else { return ScanResult(groups: [], skippedCount: skipped) }
+            guard !Task.isCancelled else { return ScanResult(groups: [], skippedSummary: skippedSummary) }
 
             let asset = assets.object(at: i)
             let photoResource = PHAssetResource.assetResources(for: asset).first(where: { $0.type == .photo })
 
             guard StillImageEligibility.isComparableStillPhotoAsset(asset, resource: photoResource) else {
-                skipped += 1
+                skippedSummary.add(
+                    name: photoResource?.originalFilename ?? "Asset \(i + 1)",
+                    detail: PhotosAssetURL.build(for: asset.localIdentifier).absoluteString,
+                    reason: .unsupportedFormat
+                )
                 continue
             }
 
@@ -130,10 +147,12 @@ struct PhotoLibraryScanner: ImageScanner {
                 fileSize = (resource.value(forKey: "fileSize") as? NSNumber)?.int64Value ?? 0
             }
 
+            let filename = photoResource?.originalFilename ?? "Photo \(i + 1)"
             candidates.append(
                 PhotoPrintCandidate(
                     url: PhotosAssetURL.build(for: asset.localIdentifier),
                     localIdentifier: asset.localIdentifier,
+                    filename: filename,
                     modificationDate: asset.modificationDate,
                     fileSize: fileSize,
                     isScreenshot: StillImageEligibility.isScreenshotPhotoAsset(asset)
@@ -162,11 +181,11 @@ struct PhotoLibraryScanner: ImageScanner {
         }
 
         let prints = printResult.prints
-        skipped += printResult.skipped
+        skippedSummary.merge(printResult.skippedSummary)
 
         if prints.isEmpty {
             onProgress(1.0, "Complete")
-            return ScanResult(groups: [], skippedCount: skipped)
+            return ScanResult(groups: [], skippedSummary: skippedSummary)
         }
 
         onProgress(0.5, "Comparing images...")
@@ -192,7 +211,7 @@ struct PhotoLibraryScanner: ImageScanner {
         }
 
         onProgress(1.0, "Complete")
-        return ScanResult(groups: groups, skippedCount: skipped)
+        return ScanResult(groups: groups, skippedSummary: skippedSummary)
     }
 
     /// Concurrent PhotoKit decode (768 highQuality, local-only) + FeaturePrintEngine Vision/cache.
@@ -201,17 +220,18 @@ struct PhotoLibraryScanner: ImageScanner {
         onProgress: @MainActor @Sendable @escaping (Double, String) -> Void,
         baseProgress: Double,
         progressSpan: Double
-    ) async -> (prints: [FeaturePrintEngine.Entry], skipped: Int) {
+    ) async -> (prints: [FeaturePrintEngine.Entry], skippedSummary: SkippedSummary, skipped: Int) {
         let limit = min(
             AppConstants.Scan.maxConcurrentFeaturePrints,
             max(1, ProcessInfo.processInfo.activeProcessorCount)
         )
         let total = candidates.count
-        if total == 0 { return ([], 0) }
+        if total == 0 { return ([], SkippedSummary(), 0) }
 
         let maxPixel = AppConstants.Scan.featurePrintMaxPixelSize
         let counter = PhotoProgressCounter()
         var results: [FeaturePrintEngine.Entry?] = Array(repeating: nil, count: total)
+        var skippedSummary = SkippedSummary()
         var skipped = 0
 
         await withTaskGroup(of: (Int, FeaturePrintEngine.Entry?).self) { group in
@@ -238,6 +258,11 @@ struct PhotoLibraryScanner: ImageScanner {
                     results[index] = entry
                 } else {
                     skipped += 1
+                    skippedSummary.add(
+                        name: candidates[index].filename,
+                        detail: candidates[index].url.absoluteString,
+                        reason: .inCloudOnly
+                    )
                 }
 
                 let done = counter.increment()
@@ -249,7 +274,7 @@ struct PhotoLibraryScanner: ImageScanner {
             }
         }
 
-        return (results.compactMap { $0 }, skipped)
+        return (results.compactMap { $0 }, skippedSummary, skipped)
     }
 
     /// Background-safe: re-fetches PHAsset by id, sync PhotoKit request, then engine print/cache.

--- a/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
+++ b/Sources/TwinPixCleaner/Core/SimilarityDetector.swift
@@ -32,9 +32,9 @@ public struct SimilarityDetector: ImageScanner {
             let prints = printResult.prints.map {
                 ($0.url, $0.vector, StillImageEligibility.isScreenshotFile($0.url))
             }
-            let skipped = printResult.skipped
+            let skippedSummary = printResult.skippedSummary
 
-            if prints.isEmpty { return ScanResult(groups: [], skippedCount: skipped) }
+            if prints.isEmpty { return ScanResult(groups: [], skippedSummary: skippedSummary) }
 
             await onProgress(0.8, "Comparing images…")
             let clusters = await FeaturePrintClustering.clusterSeparatingScreenshots(
@@ -57,7 +57,7 @@ public struct SimilarityDetector: ImageScanner {
             }
 
             await onProgress(1.0, "Complete")
-            return ScanResult(groups: groups, skippedCount: skipped)
+            return ScanResult(groups: groups, skippedSummary: skippedSummary)
         }.value
     }
 }

--- a/Sources/TwinPixCleaner/Core/SkippedItem.swift
+++ b/Sources/TwinPixCleaner/Core/SkippedItem.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SwiftUI
+
+/// Categorized reason why an item was skipped during a scan.
+public enum SkipReason: String, CaseIterable, Identifiable, Sendable {
+    case inCloudOnly = "Stored in iCloud"
+    case unsupportedFormat = "Video / Animated Media"
+    case unreadableFile = "Unreadable or Corrupt File"
+
+    public var id: String { rawValue }
+
+    public var icon: String {
+        switch self {
+        case .inCloudOnly:
+            return "icloud.slash"
+        case .unsupportedFormat:
+            return "video.slash"
+        case .unreadableFile:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    public var explanatoryText: String {
+        switch self {
+        case .inCloudOnly:
+            return "Photo is stored only in iCloud and not downloaded locally on this Mac."
+        case .unsupportedFormat:
+            return "Video, GIF, or animated container excluded from still photo compares."
+        case .unreadableFile:
+            return "File could not be opened, read, or hashed due to disk permissions or corruption."
+        }
+    }
+}
+
+/// A recorded sample of an asset or file that was skipped.
+public struct SkippedItem: Identifiable, Hashable, Sendable {
+    public let id: String
+    public let name: String
+    public let detail: String?
+    public let reason: SkipReason
+
+    public init(id: String = UUID().uuidString, name: String, detail: String? = nil, reason: SkipReason) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.reason = reason
+    }
+}
+
+/// Aggregated summary of skipped items across an entire scan.
+/// To preserve low memory usage on 50k+ photo libraries, `sampleItems` is capped at 100 entries
+/// while `totalCount` and `reasonCounts` track 100% of skipped assets.
+public struct SkippedSummary: Sendable, Equatable {
+    public static let maxSamples = 100
+
+    public private(set) var totalCount: Int = 0
+    public private(set) var reasonCounts: [SkipReason: Int] = [:]
+    public private(set) var sampleItems: [SkippedItem] = []
+
+    public init() {}
+
+    public init(totalCount: Int, reasonCounts: [SkipReason: Int], sampleItems: [SkippedItem]) {
+        self.totalCount = totalCount
+        self.reasonCounts = reasonCounts
+        self.sampleItems = Array(sampleItems.prefix(Self.maxSamples))
+    }
+
+    public mutating func add(name: String, detail: String? = nil, reason: SkipReason) {
+        totalCount += 1
+        reasonCounts[reason, default: 0] += 1
+        if sampleItems.count < Self.maxSamples {
+            sampleItems.append(SkippedItem(name: name, detail: detail, reason: reason))
+        }
+    }
+
+    public mutating func merge(_ other: SkippedSummary) {
+        totalCount += other.totalCount
+        for (reason, count) in other.reasonCounts {
+            reasonCounts[reason, default: 0] += count
+        }
+        let availableSlots = Self.maxSamples - sampleItems.count
+        if availableSlots > 0 {
+            sampleItems.append(contentsOf: other.sampleItems.prefix(availableSlots))
+        }
+    }
+}

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -35,6 +35,7 @@ class AppViewModel: ObservableObject {
         let trashedURL: URL
         let groupHash: String
         let groupFileSize: Int64
+        let allGroupURLs: [URL]
     }
     @Published var deletionHistory: [DeletedFileRecord] = []
     @Published var showUndoToast: Bool = false
@@ -192,7 +193,8 @@ class AppViewModel: ObservableObject {
                         originalURL: url,
                         trashedURL: trashedURL,
                         groupHash: matchingGroup?.hash ?? "",
-                        groupFileSize: matchingGroup?.fileSize ?? 0
+                        groupFileSize: matchingGroup?.fileSize ?? 0,
+                        allGroupURLs: matchingGroup?.fileURLs ?? [url]
                     ))
                     deletedCount += 1
                 } else {
@@ -230,7 +232,8 @@ class AppViewModel: ObservableObject {
                 originalURL: url,
                 trashedURL: trashedURL,
                 groupHash: group.hash,
-                groupFileSize: group.fileSize
+                groupFileSize: group.fileSize,
+                allGroupURLs: group.fileURLs
             ))
 
             if let index = groups.firstIndex(where: { $0.id == group.id }) {
@@ -298,19 +301,28 @@ class AppViewModel: ObservableObject {
             // Re-insert into the matching group or create a new one
             if let index = groups.firstIndex(where: { $0.hash == record.groupHash }) {
                 var updatedURLs = groups[index].fileURLs
-                updatedURLs.append(record.originalURL)
+                if !updatedURLs.contains(record.originalURL) {
+                    updatedURLs.append(record.originalURL)
+                }
                 groups[index] = DuplicateGroup(
                     hash: groups[index].hash,
                     fileSize: groups[index].fileSize,
                     fileURLs: updatedURLs
                 )
             } else {
-                // Group was removed — recreate it with just this file pair
-                // (won't happen often; the group only disappears if < 2 files remain)
+                // Group was removed because remaining count fell below 2.
+                // Reconstruct the group preserving the surviving files and this restored file.
+                var restoredURLs = record.allGroupURLs.filter { url in
+                    if url == record.originalURL { return true }
+                    return !deletionHistory.contains(where: { $0.originalURL == url })
+                }
+                if !restoredURLs.contains(record.originalURL) {
+                    restoredURLs.append(record.originalURL)
+                }
                 groups.append(DuplicateGroup(
                     hash: record.groupHash,
                     fileSize: record.groupFileSize,
-                    fileURLs: [record.originalURL]
+                    fileURLs: restoredURLs
                 ))
             }
             

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -1,6 +1,4 @@
 import SwiftUI
-import Combine
-import Quartz
 import Photos
 
 // Synthesized Equatable: DuplicateGroup is itself Equatable, so `.results` compares the

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -187,9 +187,13 @@ class AppViewModel: ObservableObject {
     func deleteSelectedFiles() {
         guard case .results(var groups) = state else { return }
 
-        var failedDeletions: [String] = []
-        var deletedCount = 0
+        NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+
         let urlsToDelete = Array(selectedFiles)
+        guard !urlsToDelete.isEmpty else { return }
+
+        var deletedCount = 0
+        var failedDeletions: [String] = []
 
         do {
             let results = try FileDeleter.deleteFiles(at: urlsToDelete)
@@ -234,6 +238,8 @@ class AppViewModel: ObservableObject {
     func deleteFile(url: URL, in group: DuplicateGroup) {
         guard case .results(var groups) = state else { return }
 
+        NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+
         do {
             let trashedURL = try FileDeleter.deleteFile(at: url)
             deletionHistory.append(DeletedFileRecord(
@@ -244,7 +250,7 @@ class AppViewModel: ObservableObject {
                 allGroupURLs: group.fileURLs
             ))
 
-            if let index = groups.firstIndex(where: { $0.id == group.id }) {
+            if let index = groups.firstIndex(where: { $0.id == group.id || $0.fileURLs.contains(url) }) {
                 let updatedURLs = groups[index].fileURLs.filter { $0 != url }
 
                 if updatedURLs.count > 1 {

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -43,6 +43,12 @@ class AppViewModel: ObservableObject {
     private var scanTask: Task<Void, Never>?
     private var undoToastDismissTask: Task<Void, Never>?
     private var metadataCache: [URL: String] = [:]
+
+    init() {
+        Task.detached(priority: .background) {
+            FeaturePrintEngine.pruneCache()
+        }
+    }
     
     func startScanning(directory: URL) {
         state = .scanning

--- a/Sources/TwinPixCleaner/UI/AppViewModel.swift
+++ b/Sources/TwinPixCleaner/UI/AppViewModel.swift
@@ -27,6 +27,8 @@ class AppViewModel: ObservableObject {
     @Published var scanMode: ScanMode = .exact
     @Published var showUserGuide: Bool = false
     @Published var lastScanSkippedCount: Int = 0
+    @Published var lastScanSkippedSummary: SkippedSummary = SkippedSummary()
+    @Published var showSkippedFilesSheet: Bool = false
     
     let quickLookCoordinator = QuickLookCoordinator()
 
@@ -59,6 +61,7 @@ class AppViewModel: ObservableObject {
         currentFile = ""
         appError = nil
         lastScanSkippedCount = 0
+        lastScanSkippedSummary = SkippedSummary()
 
         let mode = scanMode
 
@@ -76,6 +79,7 @@ class AppViewModel: ObservableObject {
                     self.state = .results(result.groups)
                     self.duplicateCount = result.groups.count
                     self.lastScanSkippedCount = result.skippedCount
+                    self.lastScanSkippedSummary = result.skippedSummary
                 }
             } catch {
                 if !Task.isCancelled {
@@ -100,6 +104,7 @@ class AppViewModel: ObservableObject {
         currentFile = ""
         appError = nil
         lastScanSkippedCount = 0
+        lastScanSkippedSummary = SkippedSummary()
 
         let mode = scanMode
 
@@ -126,6 +131,7 @@ class AppViewModel: ObservableObject {
                         self.state = .results(result.groups)
                         self.duplicateCount = result.groups.count
                         self.lastScanSkippedCount = result.skippedCount
+                        self.lastScanSkippedSummary = result.skippedSummary
                     }
                 }
             } catch {
@@ -150,6 +156,8 @@ class AppViewModel: ObservableObject {
         duplicateCount = 0
         selectedFiles.removeAll()
         lastScanSkippedCount = 0
+        lastScanSkippedSummary = SkippedSummary()
+        showSkippedFilesSheet = false
         metadataCache.removeAll()
     }
     

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -93,7 +93,7 @@ struct DashboardView: View {
                 Button(action: {
                     viewModel.startPhotosScanning()
                 }) {
-                    Label("Scan Apple Photos", systemImage: "photo.on.rectangle.angled")
+                    Label("Scan Apple Photos", systemImage: AppConstants.Icons.photoCopies)
                         .font(.headline)
                         .padding(.vertical, 12)
                         .padding(.horizontal, 16)

--- a/Sources/TwinPixCleaner/UI/DashboardView.swift
+++ b/Sources/TwinPixCleaner/UI/DashboardView.swift
@@ -173,7 +173,7 @@ struct DashboardView: View {
             }
 
             VStack(spacing: 4) {
-                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.1.0") • Made with ❤️ for macOS")
+                Text("© 2026 TwinPixCleaner v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.2.0") • Made with ❤️ for macOS")
                     .font(.caption2)
                     .foregroundColor(.secondary)
 

--- a/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
+++ b/Sources/TwinPixCleaner/UI/DuplicateItemView.swift
@@ -47,7 +47,7 @@ struct DuplicateItemView: View {
             // doesn't keep intercepting the Space key from the global Quick Look shortcut
             // (a focused button on macOS treats Space as its own press).
             DispatchQueue.main.async {
-                NSApp.keyWindow?.makeFirstResponder(nil)
+                NSApplication.shared.keyWindow?.makeFirstResponder(nil)
             }
         }) {
             ZStack(alignment: .topTrailing) {
@@ -191,7 +191,14 @@ private struct ActionBarButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(action: {
+            // Dismiss active focus so removing the item does not cause
+            // AppKit to jump focus to preceding rows and scroll the view up.
+            DispatchQueue.main.async {
+                NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+            }
+            action()
+        }) {
             HStack(spacing: 4) {
                 Image(systemName: icon)
                     .font(.system(size: 11, weight: .medium))
@@ -201,8 +208,8 @@ private struct ActionBarButton: View {
             .foregroundColor(tint)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .contentShape(Rectangle())
     }
 }

--- a/Sources/TwinPixCleaner/UI/FrostTheme.swift
+++ b/Sources/TwinPixCleaner/UI/FrostTheme.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 public struct FrostTheme {
     // Background gradient for light mode
     public static let backgroundGradient = LinearGradient(
@@ -59,6 +60,7 @@ public struct FrostTheme {
 
     /// Semantic color tokens built on top of the accent-derived gradient and a few
     /// standard system colors, replacing the scattered ad-hoc tints used across the UI.
+    @MainActor
     public enum Colors {
         public static var brand: Color { accentStops?.0 ?? Color(red: 0.39, green: 0.40, blue: 0.95) }
         public static var brandAlt: Color { accentStops?.1 ?? Color(red: 0.66, green: 0.33, blue: 0.97) }

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -36,8 +36,8 @@ struct MenuCommands: Commands {
         CommandGroup(replacing: .appInfo) {
             Button("About TwinPixCleaner") {
                 let info = Bundle.main.infoDictionary
-                let version = info?["CFBundleShortVersionString"] as? String ?? "2.1.0"
-                let build = info?["CFBundleVersion"] as? String ?? "1"
+                let version = info?["CFBundleShortVersionString"] as? String ?? "2.2.0"
+                let build = info?["CFBundleVersion"] as? String ?? "4"
                 NSApplication.shared.orderFrontStandardAboutPanel(
                     options: [
                         .applicationName: AppConstants.Strings.appName,

--- a/Sources/TwinPixCleaner/UI/MenuCommands.swift
+++ b/Sources/TwinPixCleaner/UI/MenuCommands.swift
@@ -25,6 +25,12 @@ struct MenuCommands: Commands {
                 viewModel.showUserGuide = true
             }
             .keyboardShortcut("?", modifiers: .command)
+
+            Divider()
+
+            Button("Clear Similarity Cache") {
+                FeaturePrintEngine.clearCache()
+            }
         }
 
         CommandGroup(replacing: .appInfo) {

--- a/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
+++ b/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
@@ -131,7 +131,7 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
             )
             return fileURL
         } catch {
-            print("Failed to write temp photo for quicklook: \(error)")
+            AppLogger.quickLook.error("Failed to write temp photo for quicklook: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
+++ b/Sources/TwinPixCleaner/UI/QuickLookCoordinator.swift
@@ -7,12 +7,32 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
     var previewURLs: [URL] = []
     var currentIndex: Int = 0
     private var tempPhotoURLs: [URL: URL] = [:]
+
+    nonisolated private static var tempDirectory: URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("TwinPixCleaner_QL", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
+    /// Cleans up any orphaned temporary preview files from current or past sessions.
+    nonisolated static func cleanupTempDirectory() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("TwinPixCleaner_QL", isDirectory: true)
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    override init() {
+        super.init()
+        Self.cleanupTempDirectory()
+    }
     
     deinit {
         // Clean up any leaked temp files when the coordinator is deallocated (e.g. app quit)
         for (_, tempURL) in tempPhotoURLs {
             try? FileManager.default.removeItem(at: tempURL)
         }
+        Self.cleanupTempDirectory()
     }
     
     // MARK: - QLPreviewPanelDataSource
@@ -97,7 +117,7 @@ class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDe
             ext = "jpg"
         }
 
-        let tempDir = FileManager.default.temporaryDirectory
+        let tempDir = Self.tempDirectory
         let fileURL = tempDir.appendingPathComponent(UUID().uuidString + "." + ext)
 
         do {

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -256,7 +256,7 @@ struct ResultsView: View {
         .onAppear {
             // Ensure the view can receive keyboard events
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                NSApp.keyWindow?.makeFirstResponder(nil)
+                NSApplication.shared.keyWindow?.makeFirstResponder(nil)
             }
         }
     }

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -67,6 +67,9 @@ struct ResultsView: View {
             }
         }
         .animation(.easeOut(duration: 0.25), value: viewModel.showUndoToast)
+        .sheet(isPresented: $viewModel.showSkippedFilesSheet) {
+            SkippedFilesSheetView(summary: viewModel.lastScanSkippedSummary)
+        }
     }
 
     private var undoToast: some View {
@@ -92,13 +95,26 @@ struct ResultsView: View {
     }
 
     private var skippedFilesBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: AppConstants.Icons.warningTriangle)
-                .foregroundColor(FrostTheme.Colors.warning)
-            Text("\(viewModel.lastScanSkippedCount) \(AppConstants.Strings.filesSkippedSuffix)")
+        HStack(spacing: 10) {
+            Image(systemName: "info.circle.fill")
+                .foregroundColor(FrostTheme.Colors.brand)
+            Text("\(viewModel.lastScanSkippedCount) \(viewModel.lastScanSkippedCount == 1 ? "item" : "items") skipped during scan (iCloud / non-photo items)")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(.secondary)
+            
             Spacer()
+            
+            Button {
+                viewModel.showSkippedFilesSheet = true
+            } label: {
+                HStack(spacing: 4) {
+                    Text("View Details")
+                    Image(systemName: "arrow.up.right.square")
+                }
+                .font(.system(size: 11, weight: .semibold))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)

--- a/Sources/TwinPixCleaner/UI/ResultsView.swift
+++ b/Sources/TwinPixCleaner/UI/ResultsView.swift
@@ -195,7 +195,7 @@ struct ResultsView: View {
                         Button(action: {
                             viewModel.deleteSelectedFiles()
                         }) {
-                            Label("\(AppConstants.Strings.deleteSelected) \(viewModel.selectedFiles.count)", systemImage: "trash")
+                            Label("\(AppConstants.Strings.deleteSelected) \(viewModel.selectedFiles.count)", systemImage: AppConstants.Icons.trash)
                                 .font(.system(size: 13, weight: .medium))
                                 .padding(.horizontal, 16)
                                 .padding(.vertical, 8)

--- a/Sources/TwinPixCleaner/UI/SkippedFilesSheetView.swift
+++ b/Sources/TwinPixCleaner/UI/SkippedFilesSheetView.swift
@@ -1,0 +1,323 @@
+import SwiftUI
+import AppKit
+
+struct SkippedFilesSheetView: View {
+    let summary: SkippedSummary
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var selectedReason: SkipReason? = nil
+    @State private var searchText = ""
+    @State private var copiedToClipboard = false
+    
+    private var filteredItems: [SkippedItem] {
+        var items = summary.sampleItems
+        if let selectedReason {
+            items = items.filter { $0.reason == selectedReason }
+        }
+        if !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            items = items.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText) ||
+                ($0.detail?.localizedCaseInsensitiveContains(searchText) ?? false)
+            }
+        }
+        return items
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            headerBar
+            Divider()
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    categoryCards
+                    
+                    if summary.reasonCounts[.inCloudOnly, default: 0] > 0 {
+                        infoNoticeCallout
+                    }
+                    
+                    categoryFilterTabs
+                    
+                    sampleListSection
+                }
+                .padding(20)
+            }
+            
+            Divider()
+            footerBar
+        }
+        .frame(width: 620, height: 520)
+        .frostBackground()
+    }
+    
+    private var headerBar: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "info.circle.fill")
+                .font(.system(size: 20))
+                .foregroundStyle(FrostTheme.Colors.brand)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Skipped Items")
+                    .font(.headline)
+                Text("\(summary.totalCount) item\(summary.totalCount == 1 ? "" : "s") skipped during scan")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            Button("Done") {
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .background(.ultraThinMaterial)
+    }
+    
+    private var categoryCards: some View {
+        HStack(spacing: 12) {
+            if let cloudCount = summary.reasonCounts[.inCloudOnly], cloudCount > 0 {
+                ReasonStatCard(
+                    icon: "icloud.slash.fill",
+                    tint: .blue,
+                    count: cloudCount,
+                    title: "In iCloud",
+                    subtitle: "Not on this Mac"
+                )
+            }
+            
+            if let mediaCount = summary.reasonCounts[.unsupportedFormat], mediaCount > 0 {
+                ReasonStatCard(
+                    icon: "video.slash.fill",
+                    tint: .purple,
+                    count: mediaCount,
+                    title: "Videos & GIFs",
+                    subtitle: "Non-still media"
+                )
+            }
+            
+            if let errorCount = summary.reasonCounts[.unreadableFile], errorCount > 0 {
+                ReasonStatCard(
+                    icon: "exclamationmark.triangle.fill",
+                    tint: FrostTheme.Colors.warning,
+                    count: errorCount,
+                    title: "Unreadable",
+                    subtitle: "Corrupt or locked"
+                )
+            }
+        }
+    }
+    
+    private var infoNoticeCallout: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "icloud")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.blue)
+                .padding(.top, 1)
+            
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Why are iCloud photos skipped?")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("TwinPixCleaner skips photos that exist only in iCloud to avoid downloading gigabytes over your network and filling your Mac's storage. To include them, download them in Apple Photos first.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.blue.opacity(0.08))
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color.blue.opacity(0.2), lineWidth: 1)
+        )
+    }
+    
+    private var categoryFilterTabs: some View {
+        HStack {
+            Picker("Filter", selection: $selectedReason) {
+                Text("All (\(summary.totalCount))").tag(nil as SkipReason?)
+                
+                ForEach(SkipReason.allCases) { reason in
+                    if let count = summary.reasonCounts[reason], count > 0 {
+                        Text("\(reason.rawValue) (\(count))").tag(reason as SkipReason?)
+                    }
+                }
+            }
+            .pickerStyle(.segmented)
+            
+            Spacer()
+            
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 11))
+                TextField("Search names…", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .frame(width: 140)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.primary.opacity(0.06))
+            .cornerRadius(6)
+        }
+    }
+    
+    private var sampleListSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Sample Skipped Files")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.secondary)
+                
+                Spacer()
+                
+                if summary.totalCount > summary.sampleItems.count {
+                    Text("Showing \(filteredItems.count) of \(summary.sampleItems.count) samples")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            if filteredItems.isEmpty {
+                HStack {
+                    Spacer()
+                    Text("No skipped items match your filter")
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
+                        .padding(.vertical, 24)
+                    Spacer()
+                }
+            } else {
+                VStack(spacing: 4) {
+                    ForEach(filteredItems) { item in
+                        SkippedItemRow(item: item)
+                    }
+                }
+            }
+        }
+    }
+    
+    private var footerBar: some View {
+        HStack {
+            Button(action: copySampleNames) {
+                Label(copiedToClipboard ? "Copied!" : "Copy Sample Names", systemImage: copiedToClipboard ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.borderless)
+            .foregroundColor(copiedToClipboard ? .green : .accentColor)
+            
+            Spacer()
+            
+            Text("Press Esc to close")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial)
+    }
+    
+    private func copySampleNames() {
+        let names = filteredItems.map { $0.name }.joined(separator: "\n")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(names, forType: .string)
+        withAnimation {
+            copiedToClipboard = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation {
+                copiedToClipboard = false
+            }
+        }
+    }
+}
+
+private struct ReasonStatCard: View {
+    let icon: String
+    let tint: Color
+    let count: Int
+    let title: String
+    let subtitle: String
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 20))
+                .foregroundColor(tint)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(count)")
+                    .font(.system(size: 16, weight: .bold))
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(subtitle)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
+        .cornerRadius(12)
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5))
+    }
+}
+
+private struct SkippedItemRow: View {
+    let item: SkippedItem
+    
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: item.reason.icon)
+                .font(.system(size: 13))
+                .foregroundColor(iconColor)
+                .frame(width: 20)
+            
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                
+                if let detail = item.detail {
+                    Text(detail)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            
+            Spacer()
+            
+            Text(item.reason.rawValue)
+                .font(.system(size: 10, weight: .medium))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(iconColor.opacity(0.12))
+                .foregroundColor(iconColor)
+                .cornerRadius(6)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.ultraThinMaterial)
+        .cornerRadius(8)
+    }
+    
+    private var iconColor: Color {
+        switch item.reason {
+        case .inCloudOnly:
+            return .blue
+        case .unsupportedFormat:
+            return .purple
+        case .unreadableFile:
+            return .orange
+        }
+    }
+}

--- a/Sources/TwinPixCleaner/UI/UniversalImageView.swift
+++ b/Sources/TwinPixCleaner/UI/UniversalImageView.swift
@@ -7,6 +7,8 @@ struct UniversalImageView: View {
     @State private var image: Image?
     @State private var isLoading = false
     @State private var hasError = false
+    @State private var loadTask: Task<Void, Never>?
+    @State private var photoRequestID: PHImageRequestID?
     
     var body: some View {
         ZStack {
@@ -33,11 +35,29 @@ struct UniversalImageView: View {
         .onAppear {
             loadImage()
         }
+        .onDisappear {
+            cancelLoading()
+        }
+        .onChange(of: url) { _ in
+            loadImage()
+        }
     }
     
+    private func cancelLoading() {
+        loadTask?.cancel()
+        loadTask = nil
+        if let requestID = photoRequestID {
+            PHImageManager.default().cancelImageRequest(requestID)
+            photoRequestID = nil
+        }
+        isLoading = false
+    }
+
     private func loadImage() {
-        guard !isLoading else { return }
+        cancelLoading()
         isLoading = true
+        hasError = false
+        image = nil
         
         if url.scheme == "photos" {
             loadPhotoAsset()
@@ -47,20 +67,24 @@ struct UniversalImageView: View {
     }
     
     private func loadFileAsset() {
-        Task.detached(priority: .userInitiated) {
+        loadTask = Task.detached(priority: .userInitiated) {
             let options: [CFString: Any] = [
                 kCGImageSourceCreateThumbnailFromImageAlways: true,
                 kCGImageSourceThumbnailMaxPixelSize: 400,        // matches the Photos path's 400x400 target
                 kCGImageSourceCreateThumbnailWithTransform: true // respect EXIF orientation
             ]
-            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            guard !Task.isCancelled,
+                  let source = CGImageSourceCreateWithURL(url as CFURL, nil),
                   let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-                await MainActor.run {
-                    self.hasError = true
-                    self.isLoading = false
+                if !Task.isCancelled {
+                    await MainActor.run {
+                        self.hasError = true
+                        self.isLoading = false
+                    }
                 }
                 return
             }
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 self.image = Image(decorative: thumbnail, scale: 1.0)
                 self.isLoading = false
@@ -75,19 +99,20 @@ struct UniversalImageView: View {
             return
         }
 
-
         let manager = PHImageManager.default()
         let options = PHImageRequestOptions()
         options.isNetworkAccessAllowed = true
         options.deliveryMode = .opportunistic
         
-        manager.requestImage(
+        photoRequestID = manager.requestImage(
             for: asset,
             targetSize: CGSize(width: 400, height: 400),
             contentMode: .aspectFill,
             options: options
         ) { result, info in
             DispatchQueue.main.async {
+                let isCancelled = (info?[PHImageCancelledKey] as? Bool) ?? false
+                if isCancelled { return }
                 if let nsImage = result {
                     self.image = Image(nsImage: nsImage)
                 } else {

--- a/Sources/TwinPixCleaner/UI/UserGuideView.swift
+++ b/Sources/TwinPixCleaner/UI/UserGuideView.swift
@@ -20,9 +20,14 @@ struct UserGuideView: View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text("User Guide")
-                    .font(.title2)
-                    .fontWeight(.bold)
+                HStack(spacing: 8) {
+                    Image(systemName: "book.fill")
+                        .font(.title3)
+                        .foregroundStyle(FrostTheme.Colors.brand)
+                    Text("TwinPixCleaner User Guide")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
                 Spacer()
                 Button("Done") {
                     dismiss()
@@ -36,68 +41,92 @@ struct UserGuideView: View {
             
             // Content
             ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 16) {
                     GuideSection {
                         Text("Getting Started")
-                            .font(.title)
+                            .font(.title2)
                             .fontWeight(.bold)
                         
-                        Text("TwinPixCleaner helps you find and remove duplicate images to free up disk space.")
+                        Text("TwinPixCleaner uses Apple Silicon and Vision Intelligence to safely detect duplicate and visually similar photos on your Mac and Apple Photos library.")
                         
                         Text("Scanning Modes")
-                            .font(.title2)
-                            .fontWeight(.semibold)
-                            .padding(.top, 8)
+                            .font(.headline)
+                            .padding(.top, 4)
                         
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("1. Exact Match (Default)")
-                                .font(.headline)
-                            Text("Finds files that are bit-for-bit identical. Safe to delete any copy.")
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "checkmark.seal.fill")
+                                    .foregroundColor(FrostTheme.Colors.brand)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Exact Match (Default)")
+                                        .font(.subheadline)
+                                        .fontWeight(.semibold)
+                                    Text("Uses SHA-256 hashing to find bit-for-bit identical files. Safe to delete any duplicate copy.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
                             
-                            Text("2. Visual Similarity")
-                                .font(.headline)
-                                .padding(.top, 4)
-                            Text("Finds images that look similar but may have differences (size, format, edits).")
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "sparkles")
+                                    .foregroundColor(FrostTheme.Colors.brandAlt)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Visual Similarity")
+                                        .font(.subheadline)
+                                        .fontWeight(.semibold)
+                                    Text("Uses Apple Vision ML feature prints to cluster near-identical shots, resized images, and bursts.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
                         }
-                        .padding(.leading)
                     }
                     
                     GuideSection {
-                        Text("How to Scan")
+                        Text("Scanning Sources")
                             .font(.title2)
-                            .fontWeight(.semibold)
+                            .fontWeight(.bold)
                         
-                        Text("1. Click 'Select Folder to Scan' or drag & drop a folder.")
-                        Text("2. OR click 'Scan Apple Photos' to scan your entire iCloud/local library.")
-                        Text("3. Wait for the scan to complete.")
-                        Text("4. Review the results.")
-                        
-                        Text("Reviewing & Deleting")
-                            .font(.title2)
-                            .fontWeight(.semibold)
-                            .padding(.top, 8)
-                        
-                        Text("• Select files to delete by clicking them.")
-                        Text("• Use Multi-select by clicking multiple files.")
-                        Text("• Press Spacebar to preview an image.")
-                        Text("• Press Delete key to remove selected files.")
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("• **Folder Scanning**: Click 'Select Folder to Scan' or drag and drop any folder directly onto the app.")
+                            Text("• **Apple Photos Library**: Click 'Scan Apple Photos' to analyze your Photos library without uploading to any external servers.")
+                        }
+                        .font(.subheadline)
                     }
                     
                     GuideSection {
-                        Text("Tips")
+                        Text("Reviewing, Quick Look & Deletion")
                             .font(.title2)
-                            .fontWeight(.semibold)
+                            .fontWeight(.bold)
                         
-                        Text("• Always check the file path before deleting.")
-                        Text("• Use 'Exact Match' for safe, automated cleanup.")
-                        Text("• Use 'Visual Similarity' to find edited copies.")
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("• **Card Selection**: Click any photo thumbnail to toggle it for batch deletion.")
+                            Text("• **Keep This**: Click 'Keep This' on a photo to preserve it and automatically select all other copies in that group.")
+                            Text("• **Select All Duplicates**: Use the button in each group header to keep the first photo and select all copies.")
+                            Text("• **Quick Look Preview**: Press **Spacebar** on any card for an instant, full-resolution preview.")
+                            Text("• **Safe Undo**: Made a mistake? Press **⌘Z** or click **'Undo'** on the toast notification to restore trashed files.")
+                        }
+                        .font(.subheadline)
+                    }
+                    
+                    GuideSection {
+                        Text("Skipped Items & iCloud")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("• **iCloud Photos**: Photos stored exclusively in iCloud are skipped to protect your internet bandwidth and avoid filling your local disk storage.")
+                            Text("• **View Details**: Click 'View Details' on the top banner after a scan to see a categorized breakdown of skipped iCloud items and non-still media.")
+                            Text("• **Clear Similarity Cache**: Use **Help ➔ Clear Similarity Cache** in the macOS menu bar to free disk space taken by cached feature prints.")
+                        }
+                        .font(.subheadline)
                     }
                 }
-                .padding(24)
+                .padding(20)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(width: 600, height: 500)
+        .frame(width: 620, height: 520)
         .frostBackground()
     }
 }

--- a/Tests/TwinPixCleanerTests/EndToEndWorkflowTests.swift
+++ b/Tests/TwinPixCleanerTests/EndToEndWorkflowTests.swift
@@ -114,4 +114,44 @@ final class EndToEndWorkflowTests: XCTestCase {
             XCTFail("State should be results with restored group")
         }
     }
+
+    // MARK: - Sequential Deletions in Multi-Item Group
+
+    @MainActor
+    func testSequentialSingleFileDeletionsInMultipleItemDuplicateGroup() {
+        let vm = AppViewModel()
+        let urlA = tempFolder.appendingPathComponent("multi_a.png")
+        let urlB = tempFolder.appendingPathComponent("multi_b.png")
+        let urlC = tempFolder.appendingPathComponent("multi_c.png")
+        try? Data("multi-same".utf8).write(to: urlA)
+        try? Data("multi-same".utf8).write(to: urlB)
+        try? Data("multi-same".utf8).write(to: urlC)
+
+        let initialGroup = DuplicateGroup(hash: "multi-hash", fileSize: 10, fileURLs: [urlA, urlB, urlC])
+        vm.state = .results([initialGroup])
+
+        // Delete first duplicate
+        vm.deleteFile(url: urlA, in: initialGroup)
+        XCTAssertNil(vm.appError)
+
+        if case .results(let remainingGroups) = vm.state {
+            XCTAssertEqual(remainingGroups.count, 1)
+            XCTAssertEqual(remainingGroups[0].fileURLs.count, 2)
+            XCTAssertFalse(remainingGroups[0].fileURLs.contains(urlA))
+            XCTAssertTrue(remainingGroups[0].fileURLs.contains(urlB))
+            XCTAssertTrue(remainingGroups[0].fileURLs.contains(urlC))
+        } else {
+            XCTFail("State should have 1 group with 2 remaining files")
+        }
+
+        // Delete second duplicate in the same group
+        vm.deleteFile(url: urlB, in: initialGroup)
+        XCTAssertNil(vm.appError)
+
+        if case .results(let finalGroups) = vm.state {
+            XCTAssertTrue(finalGroups.isEmpty, "Group should be removed when only 1 copy remains")
+        } else {
+            XCTFail("State should be results")
+        }
+    }
 }

--- a/Tests/TwinPixCleanerTests/EndToEndWorkflowTests.swift
+++ b/Tests/TwinPixCleanerTests/EndToEndWorkflowTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import SwiftUI
+@testable import TwinPixCleaner
+
+final class EndToEndWorkflowTests: XCTestCase {
+
+    var tempFolder: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TwinPixCleanerTests_\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempFolder {
+            try? FileManager.default.removeItem(at: tempFolder)
+        }
+        super.tearDown()
+    }
+
+    /// Helper to create a simple PNG image of given dimensions and color
+    private func createTestImage(filename: String, color: NSColor = .red, size: CGSize = CGSize(width: 50, height: 50)) -> URL {
+        let image = NSImage(size: size)
+        image.lockFocus()
+        color.drawSwatch(in: NSRect(origin: .zero, size: size))
+        image.unlockFocus()
+
+        let fileURL = tempFolder.appendingPathComponent(filename)
+        if let tiffData = image.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let pngData = bitmap.representation(using: .png, properties: [:]) {
+            try? pngData.write(to: fileURL)
+        }
+        return fileURL
+    }
+
+    // MARK: - Exact Scan End-to-End
+
+    @MainActor
+    func testExactMatchScannerDetectsBitForBitDuplicates() async throws {
+        // Create 2 identical files and 1 different file
+        let img1 = createTestImage(filename: "photo1.png", color: .blue).resolvingSymlinksInPath()
+        let img2 = tempFolder.appendingPathComponent("photo2.png").resolvingSymlinksInPath()
+        try FileManager.default.copyItem(at: img1, to: img2)
+        _ = createTestImage(filename: "photo3.png", color: .green, size: CGSize(width: 80, height: 80))
+
+        let detector = DuplicateDetector()
+        let result = try await detector.scan(in: tempFolder) { _, _ in }
+
+        XCTAssertEqual(result.groups.count, 1)
+        XCTAssertEqual(result.groups[0].fileURLs.count, 2)
+        let resolvedURLs = result.groups[0].fileURLs.map { $0.resolvingSymlinksInPath() }
+        XCTAssertTrue(resolvedURLs.contains(img1))
+        XCTAssertTrue(resolvedURLs.contains(img2))
+        XCTAssertEqual(result.skippedCount, 0)
+    }
+
+    // MARK: - Visual Similarity Scan End-to-End
+
+    @MainActor
+    func testSimilarityScannerGroupsVisualDuplicates() async throws {
+        // Create identical visually colored images
+        let img1 = createTestImage(filename: "shot1.png", color: .red, size: CGSize(width: 100, height: 100)).resolvingSymlinksInPath()
+        let img2 = createTestImage(filename: "shot2.png", color: .red, size: CGSize(width: 100, height: 100)).resolvingSymlinksInPath()
+        let different = createTestImage(filename: "shot3.png", color: .cyan, size: CGSize(width: 100, height: 100)).resolvingSymlinksInPath()
+
+        let detector = SimilarityDetector()
+        let result = try await detector.scan(in: tempFolder) { _, _ in }
+
+        XCTAssertEqual(result.groups.count, 1)
+        XCTAssertEqual(result.groups[0].fileURLs.count, 2)
+        let resolvedURLs = result.groups[0].fileURLs.map { $0.resolvingSymlinksInPath() }
+        XCTAssertTrue(resolvedURLs.contains(img1))
+        XCTAssertTrue(resolvedURLs.contains(img2))
+        XCTAssertFalse(resolvedURLs.contains(different))
+    }
+
+    // MARK: - Undo State Full Group Reconstruction
+
+    @MainActor
+    func testUndoRestoresFullDuplicateGroup() {
+        let vm = AppViewModel()
+        let urlA = tempFolder.appendingPathComponent("a.png")
+        let urlB = tempFolder.appendingPathComponent("b.png")
+        try? Data("same".utf8).write(to: urlA)
+        try? Data("same".utf8).write(to: urlB)
+
+        let initialGroup = DuplicateGroup(hash: "test-hash", fileSize: 4, fileURLs: [urlA, urlB])
+        vm.state = .results([initialGroup])
+
+        // Select and delete urlB
+        vm.selectedFiles = [urlB]
+        vm.deleteSelectedFiles()
+
+        // Group dropped because remaining count < 2
+        if case .results(let remainingGroups) = vm.state {
+            XCTAssertTrue(remainingGroups.isEmpty)
+        } else {
+            XCTFail("State should be results")
+        }
+
+        // Undo deletion
+        vm.undoLastDeletion()
+
+        // Verify that the restored group has BOTH files (not just [urlB])
+        if case .results(let restoredGroups) = vm.state {
+            XCTAssertEqual(restoredGroups.count, 1)
+            XCTAssertEqual(restoredGroups[0].fileURLs.count, 2)
+            XCTAssertTrue(restoredGroups[0].fileURLs.contains(urlA))
+            XCTAssertTrue(restoredGroups[0].fileURLs.contains(urlB))
+        } else {
+            XCTFail("State should be results with restored group")
+        }
+    }
+}

--- a/Tests/TwinPixCleanerTests/FeaturePrintClusteringTests.swift
+++ b/Tests/TwinPixCleanerTests/FeaturePrintClusteringTests.swift
@@ -135,4 +135,18 @@ final class FeaturePrintClusteringTests: XCTestCase {
         XCTAssertEqual(groups.count, 1)
         XCTAssertEqual(Set(groups[0]), Set([c, d]))
     }
+
+    func testCacheStoreLoadAndClear() {
+        let key = "test-key-\(UUID().uuidString)"
+        let vector: [Float] = [1.0, 2.0, 3.0, 4.0]
+
+        FeaturePrintEngine.storeCachedVector(vector, cacheKey: key)
+        let loaded = FeaturePrintEngine.loadCachedVector(cacheKey: key)
+        XCTAssertEqual(loaded, vector)
+
+        let cleared = FeaturePrintEngine.clearCache()
+        XCTAssertTrue(cleared)
+        let loadedAfterClear = FeaturePrintEngine.loadCachedVector(cacheKey: key)
+        XCTAssertNil(loadedAfterClear)
+    }
 }

--- a/Tests/TwinPixCleanerTests/SkippedSummaryTests.swift
+++ b/Tests/TwinPixCleanerTests/SkippedSummaryTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import TwinPixCleaner
+
+final class SkippedSummaryTests: XCTestCase {
+
+    func testSkippedSummaryCapsSampleItemsAtMaxSamples() {
+        var summary = SkippedSummary()
+
+        for i in 1...250 {
+            summary.add(name: "Photo_\(i).heic", detail: "photos://\(i)", reason: .inCloudOnly)
+        }
+
+        XCTAssertEqual(summary.totalCount, 250)
+        XCTAssertEqual(summary.sampleItems.count, 100)
+        XCTAssertEqual(summary.reasonCounts[.inCloudOnly], 250)
+        XCTAssertEqual(summary.sampleItems.first?.name, "Photo_1.heic")
+        XCTAssertEqual(summary.sampleItems.last?.name, "Photo_100.heic")
+    }
+
+    func testSkippedSummaryTracksMultipleReasons() {
+        var summary = SkippedSummary()
+
+        summary.add(name: "cloud.heic", reason: .inCloudOnly)
+        summary.add(name: "video.mp4", reason: .unsupportedFormat)
+        summary.add(name: "corrupt.png", reason: .unreadableFile)
+
+        XCTAssertEqual(summary.totalCount, 3)
+        XCTAssertEqual(summary.sampleItems.count, 3)
+        XCTAssertEqual(summary.reasonCounts[.inCloudOnly], 1)
+        XCTAssertEqual(summary.reasonCounts[.unsupportedFormat], 1)
+        XCTAssertEqual(summary.reasonCounts[.unreadableFile], 1)
+    }
+
+    func testSkippedSummaryMerge() {
+        var summary1 = SkippedSummary()
+        var summary2 = SkippedSummary()
+
+        for i in 1...60 {
+            summary1.add(name: "file_a_\(i).png", reason: .inCloudOnly)
+            summary2.add(name: "file_b_\(i).png", reason: .unreadableFile)
+        }
+
+        summary1.merge(summary2)
+
+        XCTAssertEqual(summary1.totalCount, 120)
+        XCTAssertEqual(summary1.sampleItems.count, 100) // capped at 100
+        XCTAssertEqual(summary1.reasonCounts[.inCloudOnly], 60)
+        XCTAssertEqual(summary1.reasonCounts[.unreadableFile], 60)
+    }
+}


### PR DESCRIPTION

**Skipped Files Details & Categorization** ([#7])
- **Interactive Skipped Items Pane:** Replaced the generic warning banner with an interactive [View Details] sheet.
- **Categorized Breakdown**: Clearly separates items into:
  - ☁️ Stored in iCloud (protects bandwidth & Mac storage by skipping iCloud-only assets)
  - 🎬 Videos & Animated GIFs (excluded from still comparisons)
  - ⚠️ Unreadable / Corrupt Files

- **Zero Memory Bloat:** Capped at 100 sample file names in memory while accurately counting 100% of skipped assets.
- **Search & Export**: Real-time filename filter and a "Copy Sample Names" clipboard button.